### PR TITLE
fix: normalize install commands in READMEs for docs tab rendering

### DIFF
--- a/docs/docs/reference/braintree-plugin/index.mdx
+++ b/docs/docs/reference/braintree-plugin/index.mdx
@@ -11,11 +11,6 @@ This plugin enables payments to be processed by [Braintree](https://www.braintre
 1. You will need to create a Braintree sandbox account as outlined in https://developers.braintreepayments.com/start/overview.
 2. Then install `braintree` and `@types/braintree` from npm. This plugin was written with `v3.x` of the Braintree lib.
     ```shell
-    yarn add @vendure-community/braintree-plugin braintree
-    yarn add -D @types/braintree
-    ```
-    or
-    ```shell
     npm install @vendure-community/braintree-plugin braintree
     npm install -D @types/braintree
     ```
@@ -49,8 +44,6 @@ This is a library provided by Braintree which will handle the payment UI for you
 with:
 
 ```shell
-yarn add braintree-web-drop-in
-# or
 npm install braintree-web-drop-in
 ```
 

--- a/docs/docs/reference/elasticsearch-plugin/index.mdx
+++ b/docs/docs/reference/elasticsearch-plugin/index.mdx
@@ -34,8 +34,6 @@ and testing without authentication and security enabled. Refer to ElasticSearch 
 ## Installation
 
 ```shell
-yarn add @elastic/elasticsearch @vendure/elasticsearch-plugin
-# or
 npm install @elastic/elasticsearch @vendure/elasticsearch-plugin
 ```
 

--- a/docs/docs/reference/mollie-plugin/index.mdx
+++ b/docs/docs/reference/mollie-plugin/index.mdx
@@ -12,11 +12,9 @@ This plugin uses the Order API from Mollie, not the Payments API.
 1. You will need to create a Mollie account and get your api key from the Mollie dashboard.
 2. Install the Payments plugin and the Mollie client:
 
-    `yarn add @vendure-community/mollie-plugin @mollie/api-client`
-
-    or
-
-    `npm install @vendure-community/mollie-plugin @mollie/api-client`
+    ```shell
+    npm install @vendure-community/mollie-plugin @mollie/api-client
+    ```
 
 ## Setup
 

--- a/docs/docs/reference/punch-out-gateway-plugin/index.mdx
+++ b/docs/docs/reference/punch-out-gateway-plugin/index.mdx
@@ -18,7 +18,7 @@ back to the procurement system.
 
 ## Installation
 
-```bash
+```shell
 npm install @vendure-community/punchout-gateway-plugin
 ```
 

--- a/docs/docs/reference/sentry-plugin/index.mdx
+++ b/docs/docs/reference/sentry-plugin/index.mdx
@@ -21,8 +21,8 @@ which you will need to provide to the plugin.
 
 ## Installation
 
-```sh
-npm install --save @vendure/sentry-plugin
+```shell
+npm install @vendure/sentry-plugin
 ```
 
 ## Environment Variables
@@ -47,13 +47,13 @@ Make sure the `SENTRY_DSN` environment variable is defined.
 The Sentry SDK must be initialized before your application starts. This is done by preloading
 the instrument file when starting your Vendure server:
 
-```sh
+```shell
 node --import @vendure/sentry-plugin/instrument ./dist/index.js
 ```
 
 Or if using TypeScript directly with tsx:
 
-```sh
+```shell
 tsx --import @vendure/sentry-plugin/instrument ./src/index.ts
 ```
 

--- a/docs/docs/reference/stellate-plugin/index.mdx
+++ b/docs/docs/reference/stellate-plugin/index.mdx
@@ -18,7 +18,7 @@ see the [Stellate Purging API docs](https://docs.stellate.co/docs/purging-api#au
 
 ## Installation
 
-```
+```shell
 npm install @vendure/stellate-plugin
 ```
 

--- a/docs/docs/reference/stripe-plugin/index.mdx
+++ b/docs/docs/reference/stripe-plugin/index.mdx
@@ -16,11 +16,9 @@ the Stripe CLI to test your webhook locally. See the _local development_ section
 3. Get the signing secret for the newly created webhook.
 4. Install the Payments plugin and the Stripe Node library:
 
-    `yarn add @vendure-community/stripe-plugin stripe`
-
-    or
-
-    `npm install @vendure-community/stripe-plugin stripe`
+    ```shell
+    npm install @vendure-community/stripe-plugin stripe
+    ```
 
 ## Setup
 
@@ -48,8 +46,6 @@ In this flow, Stripe provides libraries which handle the payment UI and confirma
 with:
 
 ```shell
-yarn add @stripe/stripe-js
-# or
 npm install @stripe/stripe-js
 ```
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -16,7 +16,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "ElasticsearchPlugin",
@@ -30,7 +30,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "MolliePlugin",
@@ -44,7 +44,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "PubSubPlugin",
@@ -72,7 +72,7 @@
           "lastModified": "2026-03-31T16:42:28+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "SentryPlugin",
@@ -92,7 +92,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "StellatePlugin",
@@ -118,7 +118,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     },
     {
       "title": "StripePlugin",
@@ -132,7 +132,7 @@
           "lastModified": "2026-03-31T14:38:46+02:00"
         }
       ],
-      "lastModified": "2026-04-01T17:39:16+02:00"
+      "lastModified": "2026-04-03T11:40:19+02:00"
     }
   ],
   "github": {

--- a/packages/braintree-plugin/README.md
+++ b/packages/braintree-plugin/README.md
@@ -7,11 +7,6 @@ This plugin enables payments to be processed by [Braintree](https://www.braintre
 1. You will need to create a Braintree sandbox account as outlined in https://developers.braintreepayments.com/start/overview.
 2. Then install `braintree` and `@types/braintree` from npm. This plugin was written with `v3.x` of the Braintree lib.
     ```shell
-    yarn add @vendure-community/braintree-plugin braintree
-    yarn add -D @types/braintree
-    ```
-    or
-    ```shell
     npm install @vendure-community/braintree-plugin braintree
     npm install -D @types/braintree
     ```
@@ -45,8 +40,6 @@ This is a library provided by Braintree which will handle the payment UI for you
 with:
 
 ```shell
-yarn add braintree-web-drop-in
-# or
 npm install braintree-web-drop-in
 ```
 

--- a/packages/elasticsearch-plugin/README.md
+++ b/packages/elasticsearch-plugin/README.md
@@ -30,8 +30,6 @@ and testing without authentication and security enabled. Refer to ElasticSearch 
 ## Installation
 
 ```shell
-yarn add @elastic/elasticsearch @vendure/elasticsearch-plugin
-# or
 npm install @elastic/elasticsearch @vendure/elasticsearch-plugin
 ```
 

--- a/packages/mollie-plugin/README.md
+++ b/packages/mollie-plugin/README.md
@@ -8,11 +8,9 @@ This plugin uses the Order API from Mollie, not the Payments API.
 1. You will need to create a Mollie account and get your api key from the Mollie dashboard.
 2. Install the Payments plugin and the Mollie client:
 
-    `yarn add @vendure-community/mollie-plugin @mollie/api-client`
-
-    or
-
-    `npm install @vendure-community/mollie-plugin @mollie/api-client`
+    ```shell
+    npm install @vendure-community/mollie-plugin @mollie/api-client
+    ```
 
 ## Setup
 

--- a/packages/punchout-gateway-plugin/README.md
+++ b/packages/punchout-gateway-plugin/README.md
@@ -13,7 +13,7 @@ PunchCommerce handles all protocol translation — this plugin only speaks JSON 
 
 ## Installation
 
-```bash
+```shell
 npm install @vendure-community/punchout-gateway-plugin
 ```
 

--- a/packages/sentry-plugin/README.md
+++ b/packages/sentry-plugin/README.md
@@ -21,8 +21,8 @@ which you will need to provide to the plugin.
 
 ## Installation
 
-```sh
-npm install --save @vendure/sentry-plugin
+```shell
+npm install @vendure/sentry-plugin
 ```
 
 ## Environment Variables
@@ -47,13 +47,13 @@ Make sure the `SENTRY_DSN` environment variable is defined.
 The Sentry SDK must be initialized before your application starts. This is done by preloading
 the instrument file when starting your Vendure server:
 
-```sh
+```shell
 node --import @vendure/sentry-plugin/instrument ./dist/index.js
 ```
 
 Or if using TypeScript directly with tsx:
 
-```sh
+```shell
 tsx --import @vendure/sentry-plugin/instrument ./src/index.ts
 ```
 

--- a/packages/stellate-plugin/README.md
+++ b/packages/stellate-plugin/README.md
@@ -14,7 +14,7 @@ see the [Stellate Purging API docs](https://docs.stellate.co/docs/purging-api#au
 
 ## Installation
 
-```
+```shell
 npm install @vendure/stellate-plugin
 ```
 

--- a/packages/stripe-plugin/README.md
+++ b/packages/stripe-plugin/README.md
@@ -12,11 +12,9 @@ the Stripe CLI to test your webhook locally. See the _local development_ section
 3. Get the signing secret for the newly created webhook.
 4. Install the Payments plugin and the Stripe Node library:
 
-    `yarn add @vendure-community/stripe-plugin stripe`
-
-    or
-
-    `npm install @vendure-community/stripe-plugin stripe`
+    ```shell
+    npm install @vendure-community/stripe-plugin stripe
+    ```
 
 ## Setup
 
@@ -44,8 +42,6 @@ In this flow, Stripe provides libraries which handle the payment UI and confirma
 with:
 
 ```shell
-yarn add @stripe/stripe-js
-# or
 npm install @stripe/stripe-js
 ```
 


### PR DESCRIPTION
## Summary
- Remove duplicate yarn/npm install blocks in plugin READMEs — the docs site auto-generates package manager tabs (npm/pnpm/yarn/bun) from `npm install` commands, so having both caused duplication
- Standardize code fence language tags to `shell` across all READMEs (was a mix of `sh`, `bash`, bare, and `shell`)
- Remove unnecessary `--save` flag in sentry-plugin
- Regenerate docs

## Test plan
- [ ] Verify docs site renders install commands with tabbed package manager UI without duplication