### PR TITLE
ci: add CLA assistant workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,46 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate CI Bot Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+
+      # Third-party actions are pinned to commit SHAs to prevent supply chain attacks
+      # via mutable version tags. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@9340315624c6e16cef1f2c63bdeb0f0c49c6f474 # v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          path-to-signatures: 'license/signatures/version1/cla.json'
+          path-to-document: 'https://github.com/vendurehq/community-plugins/blob/main/license/CLA.md'
+          branch: 'main'
+          allowlist: user1,bot*
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
+          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'

--- a/license/CLA.md
+++ b/license/CLA.md
@@ -1,0 +1,23 @@
+# Contributor License Agreement
+
+The following terms are used throughout this agreement:
+
+- **You** - the person or legal entity including its affiliates asked to accept this agreement. An affiliate is any entity that controls or is controlled by the legal entity, or is under common control with it.
+- **Project** - is an umbrella term that refers to any and all Vendure open source projects.
+- **Contribution** - any type of work that is submitted to a Project, including any modifications or additions to existing work.
+- **Submitted** - conveyed to a Project via a pull request, commit, issue, or any form of electronic, written, or verbal communication with Vendure, contributors or maintainers.
+- **Vendure** - the principal designation of the project, encompassing our commercial entity Vendure GmbH
+
+## 1. Grant of Copyright License.
+
+Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Vendure a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your contributions and such derivative works. Except for this license, You reserve all rights, title, and interest in your contributions.
+
+## 2. Grant of Patent License.
+
+Subject to the terms and conditions of this agreement, You grant to the Projects’ maintainers, contributors, users and to Vendure a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your contribution or by combination of your contribution with the project to which this contribution was submitted.
+
+If any entity institutes patent litigation - including cross-claim or counterclaim in a lawsuit - against You alleging that your contribution or any project it was submitted to constitutes or is responsible for direct or contributory patent infringement, then any patent licenses granted to that entity under this agreement shall terminate as of the date such litigation is filed.
+
+## 3. Source of Contribution.
+
+Your contribution is either your original creation, based upon previous work that, to the best of your knowledge, is covered under an appropriate open source license and you have the right under that license to submit that work with modifications, whether created in whole or in part by you, or you have clearly identified the source of the contribution and any license or other restriction (like related patents, trademarks, and license agreements) of which you are personally aware.


### PR DESCRIPTION
## Summary

- Adds the CLA Assistant workflow (`.github/workflows/cla.yml`), mirroring the setup in `vendurehq/vendure`
- Adds the CLA document at `license/CLA.md`
- Signatures will be stored in `license/signatures/version1/cla.json` (created automatically on first signature)

## Required follow-up before this can run

1. Install the same GitHub App that backs the CI bot in the main `vendure` repo onto `vendurehq/community-plugins`
2. Provide the secrets `CI_BOT_APP_ID` and `CI_BOT_APP_PRIVATE_KEY` — ideally as org-wide secrets on `vendurehq` so they are shared across repos

## Test plan

- [ ] Confirm GitHub App is installed on this repo
- [ ] Confirm `CI_BOT_APP_ID` and `CI_BOT_APP_PRIVATE_KEY` are available (org or repo level)
- [ ] Open a test PR from a new contributor account and verify the bot comments asking for CLA signature
- [ ] Sign with the magic string and verify the bot records the signature in `license/signatures/version1/cla.json`