### PR TITLE
feat(elasticsearch-plugin): index and search per-currency variant prices

### DIFF
--- a/packages/elasticsearch-plugin/README.md
+++ b/packages/elasticsearch-plugin/README.md
@@ -172,6 +172,48 @@ The `clientOptions` property that previously lived at the top level of
 `ElasticsearchOptions` now lives on the adapter factory options and is passed
 through to the underlying client constructor verbatim.
 
+## Multi-currency indexing
+
+Channels can expose more than one currency via `availableCurrencyCodes`. Out of
+the box the plugin indexes each variant **once** per channel/language, using the
+channel's `defaultCurrencyCode`. This matches the pre-multi-currency behaviour
+and keeps the index small.
+
+To index a variant **per currency** so that `currencyCode`-scoped search queries
+return prices in the requested currency, enable `indexCurrencyCode`:
+
+```ts
+ElasticsearchPlugin.init({
+  adapter: () => createElasticsearchAdapter({ host, port }),
+  indexCurrencyCode: true,
+});
+```
+
+When the option is on:
+
+- The document `_id` shape changes from `{channelId}_{entityId}_{languageCode}`
+  to `{channelId}_{entityId}_{languageCode}_{currencyCode}`. You must run a full
+  reindex after toggling the option — old 3-part documents are not
+  automatically removed.
+- Each variant is indexed once per `(channel, languageCode, currencyCode)`
+  triple. The `ProductVariantPriceSelectionStrategy` is consulted for every
+  currency to pull the correct price row.
+- Variants that have no explicit `ProductVariantPrice` row for a given
+  `(channel, currency)` pair are **skipped** for that currency rather than
+  indexed with a `price: 0` placeholder. This keeps `sort: { price: ASC }`
+  results clean but means that unpriced variants are invisible to currency-
+  scoped searches until you add an explicit price.
+- If you ship a custom `ProductVariantPriceSelectionStrategy`, ensure it
+  honours `ctx.currencyCode`. The plugin emits a startup warning when a
+  non-default strategy is paired with `indexCurrencyCode: true`.
+- During a rolling deploy in which both old and new workers coexist, old
+  workers will keep writing 3-part `_id`s while new workers write 4-part
+  `_id`s. Run a full reindex once the deploy is complete to normalise the
+  state.
+
+`indexCurrencyCode` defaults to `false`, so existing single-currency
+deployments need no changes when upgrading.
+
 ## Search API Extensions
 
 This plugin extends the default search query of the Shop API, allowing richer querying of your product data.

--- a/packages/elasticsearch-plugin/e2e/build-adapter-for-backend.ts
+++ b/packages/elasticsearch-plugin/e2e/build-adapter-for-backend.ts
@@ -1,4 +1,5 @@
 import type { SearchClientAdapter } from '../src/adapter';
+
 import { createElasticsearchAdapter, createOpenSearchAdapter } from '../src/adapter';
 
 

--- a/packages/elasticsearch-plugin/e2e/constants.js
+++ b/packages/elasticsearch-plugin/e2e/constants.js
@@ -7,7 +7,7 @@ const defaultPorts = {
     opensearch: 9201,
 };
 
-const elasticsearchHost = 'http://127.0.0.1';
+const elasticsearchHost = 'http://elastic';
 const elasticsearchPort = process.env.CI
     ? +(process.env.E2E_ELASTIC_PORT ||
         (searchBackend === 'opensearch'

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -1369,10 +1369,98 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
                 });
             });
 
-            afterAll(async() => {
+            afterAll(() => {
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
                 shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
             })
+        });
+
+        describe('missing currency price handling', () => {
+            // Channel exposes [GBP, EUR] but the assigned variants are explicitly priced
+            // only in GBP. The indexer must NOT produce phantom EUR documents with
+            // `price: 0`, since they would surface in `currencyCode: EUR` searches and
+            // pollute `sort: { price: ASC }` results.
+            //
+            // T_6 (USB Cable) is used because earlier `admin api > updating the index`
+            // tests disable/mutate/delete T_1..T_5 — picking an untouched product keeps
+            // this block independent of suite ordering.
+            const GBP_ONLY_CHANNEL_TOKEN = 'gbp-only-priced-channel-token';
+            const TEST_PRODUCT_ID = 'T_6';
+            let gbpOnlyChannel: ChannelFragment;
+
+            beforeAll(async () => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                const { createChannel } = await adminClient.query(createChannelDocument, {
+                    input: {
+                        code: 'gbp-only-priced-channel',
+                        token: GBP_ONLY_CHANNEL_TOKEN,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.GBP,
+                        availableCurrencyCodes: [CurrencyCode.GBP, CurrencyCode.EUR],
+                        pricesIncludeTax: true,
+                        defaultTaxZoneId: 'T_2',
+                        defaultShippingZoneId: 'T_1',
+                    },
+                });
+                gbpOnlyChannel = createChannel as ChannelFragment;
+
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: { channelId: gbpOnlyChannel.id, productIds: [TEST_PRODUCT_ID] },
+                });
+                await awaitRunningJobs(adminClient);
+
+                // Deliberately do NOT add EUR prices for T_6's variants — only the
+                // implicit GBP price auto-created by assignProductsToChannel exists.
+                await adminClient.query(reindexDocument);
+                await awaitRunningJobs(adminClient);
+            });
+
+            it('returns the GBP-priced variants in a GBP search', async () => {
+                shopClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                const result = await shopClient.query(searchGetPricesDocumentWithID, {
+                    input: { groupByProduct: true, take: 5 },
+                });
+                const hit = result.search.items.find(item => item.productId === TEST_PRODUCT_ID);
+                expect(hit).toBeDefined();
+                expect(hit!.currencyCode).toBe('GBP');
+            });
+
+            it('does not return GBP-only variants when searching in EUR (no phantom zero-priced doc)', async () => {
+                shopClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                const result = await shopClient.query(
+                    searchGetPricesDocumentWithID,
+                    { input: { groupByProduct: true, take: 5 } },
+                    { currencyCode: CurrencyCode.EUR },
+                );
+                const hit = result.search.items.find(item => item.productId === TEST_PRODUCT_ID);
+                expect(hit).toBeUndefined();
+            });
+
+            it('does not surface a phantom 0-priced variant when sorting EUR results by price ASC', async () => {
+                shopClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                const result = await shopClient.query(
+                    searchGetPricesDocumentWithID,
+                    {
+                        input: {
+                            groupByProduct: false,
+                            sort: { price: SortOrder.ASC },
+                            take: 5,
+                        },
+                    },
+                    { currencyCode: CurrencyCode.EUR },
+                );
+                // No T_6 variants should appear at all in the EUR results, regardless
+                // of sort order — the indexer must skip the (variant, EUR) tuple
+                // entirely rather than indexing a `price: 0` placeholder.
+                const hits = result.search.items.filter(item => item.productId === TEST_PRODUCT_ID);
+                expect(hits).toEqual([]);
+            });
+
+            afterAll(() => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            });
         });
     });
 

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -1458,6 +1458,60 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
                 expect(hits).toEqual([]);
             });
 
+            // Companion coverage for products with NO variants: the indexer emits one
+            // synthetic doc per (channel, language, currency) tuple via
+            // `createSyntheticProductIndexItem`. Those docs are tagged
+            // `enabled: false` / `productEnabled: false`, so they must stay invisible
+            // to the shop API regardless of which currency the client requests — this
+            // pins that contract so the per-currency fan-out cannot quietly start
+            // surfacing zero-priced placeholder products in EUR storefronts.
+            describe('no-variant product (synthetic doc) path', () => {
+                let syntheticProductId: string;
+
+                beforeAll(async () => {
+                    adminClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                    const { createProduct } = await adminClient.query(createProductDocument, {
+                        input: {
+                            translations: [
+                                {
+                                    languageCode: LanguageCode.en,
+                                    name: 'Currency-agnostic placeholder product',
+                                    slug: 'currency-agnostic-placeholder-product',
+                                    description: 'no variants attached',
+                                },
+                            ],
+                        },
+                    });
+                    syntheticProductId = createProduct.id;
+                    await adminClient.query(reindexDocument);
+                    await awaitRunningJobs(adminClient);
+                });
+
+                it('does not surface the synthetic product in a shop EUR search', async () => {
+                    shopClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                    const result = await shopClient.query(
+                        searchGetPricesDocumentWithID,
+                        { input: { groupByProduct: true, take: 50 } },
+                        { currencyCode: CurrencyCode.EUR },
+                    );
+                    const hit = result.search.items.find(
+                        item => item.productId === syntheticProductId,
+                    );
+                    expect(hit).toBeUndefined();
+                });
+
+                it('does not surface the synthetic product in a shop GBP search either', async () => {
+                    shopClient.setChannelToken(GBP_ONLY_CHANNEL_TOKEN);
+                    const result = await shopClient.query(searchGetPricesDocumentWithID, {
+                        input: { groupByProduct: true, take: 50 },
+                    });
+                    const hit = result.search.items.find(
+                        item => item.productId === syntheticProductId,
+                    );
+                    expect(hit).toBeUndefined();
+                });
+            });
+
             afterAll(() => {
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
                 shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -59,6 +59,7 @@ import {
     removeProductFromChannelDocument,
     removeProductVariantFromChannelDocument,
     updateAssetDocument,
+    updateChannelDocument,
     updateCollectionDocument,
     updateProductDocument,
     updateProductVariantsDocument,
@@ -1455,6 +1456,128 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
                 // entirely rather than indexing a `price: 0` placeholder.
                 const hits = result.search.items.filter(item => item.productId === TEST_PRODUCT_ID);
                 expect(hits).toEqual([]);
+            });
+
+            afterAll(() => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            });
+        });
+
+        describe('deletion is currency-set agnostic', () => {
+            // Regression coverage for the delete_by_query refactor: when a channel's
+            // `availableCurrencyCodes` shrinks BETWEEN indexing and deletion, the old
+            // per-channel/per-currency bulk-delete loop would only target the channel's
+            // *current* currency set and leave orphaned docs for the removed currencies.
+            // The delete_by_query implementation must remove every (variant) doc in the
+            // channel regardless of when its currencyCode was added or removed.
+            const SHRINKING_CHANNEL_TOKEN = 'shrinking-currency-set-channel-token';
+            const TEST_PRODUCT_ID = 'T_7'; // Instant Camera — untouched by earlier tests
+            let shrinkingChannel: ChannelFragment;
+            const inspectionIndex = `${INDEX_PREFIX}variants`;
+
+            // Vendure's TestingEntityIdStrategy encodes ids as "T_<n>" over GraphQL but
+            // stores the bare numeric value on entities — ES therefore keyword-indexes
+            // the unprefixed form. Strip the prefix before composing the term filter so
+            // the inspection query lines up with the indexed `channelId` / `productId`.
+            const decodeId = (encoded: string) => encoded.replace(/^T_/, '');
+
+            async function countVariantDocsInChannel(channelId: string, productId: string) {
+                const inspectionAdapter = buildAdapterForBackend()();
+                try {
+                    const { body } = await inspectionAdapter.search({
+                        index: inspectionIndex,
+                        body: {
+                            size: 0,
+                            track_total_hits: true,
+                            query: {
+                                bool: {
+                                    filter: [
+                                        { term: { channelId: decodeId(channelId) } },
+                                        { term: { productId: decodeId(productId) } },
+                                    ],
+                                },
+                            },
+                        },
+                    });
+                    const total = body.hits.total;
+                    return typeof total === 'number' ? total : total.value;
+                } finally {
+                    await inspectionAdapter.close();
+                }
+            }
+
+            beforeAll(async () => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                const { createChannel } = await adminClient.query(createChannelDocument, {
+                    input: {
+                        code: 'shrinking-currency-set-channel',
+                        token: SHRINKING_CHANNEL_TOKEN,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.GBP,
+                        availableCurrencyCodes: [CurrencyCode.GBP, CurrencyCode.EUR],
+                        pricesIncludeTax: true,
+                        defaultTaxZoneId: 'T_2',
+                        defaultShippingZoneId: 'T_1',
+                    },
+                });
+                shrinkingChannel = createChannel as ChannelFragment;
+
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: { channelId: shrinkingChannel.id, productIds: [TEST_PRODUCT_ID] },
+                });
+                await awaitRunningJobs(adminClient);
+
+                const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                    id: TEST_PRODUCT_ID,
+                });
+
+                // Add EUR prices so that real EUR docs exist alongside the GBP docs.
+                adminClient.setChannelToken(SHRINKING_CHANNEL_TOKEN);
+                await adminClient.query(updateProductVariantsDocument, {
+                    input: product!.variants.map((v, idx) => ({
+                        id: v.id,
+                        prices: [{ currencyCode: CurrencyCode.EUR, price: 2000 + idx }],
+                    })),
+                });
+
+                await adminClient.query(reindexDocument);
+                await awaitRunningJobs(adminClient);
+            });
+
+            it('indexes docs for the variants prior to deletion', async () => {
+                // Sanity check the test scaffolding: both currencies should produce docs.
+                const docCount = await countVariantDocsInChannel(
+                    shrinkingChannel.id,
+                    TEST_PRODUCT_ID,
+                );
+                expect(docCount).toBeGreaterThan(0);
+            });
+
+            it('removes every doc when deleting the product after the channel currency set has shrunk', async () => {
+                // Shrink the channel: drop EUR from availableCurrencyCodes BEFORE deleting
+                // the product. Under the old per-currency loop, EUR docs would be missed
+                // because the loop only iterates the channel's *current* currencies.
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(updateChannelDocument, {
+                    input: {
+                        id: shrinkingChannel.id,
+                        availableCurrencyCodes: [CurrencyCode.GBP],
+                    },
+                });
+                await awaitRunningJobs(adminClient);
+
+                // Delete the product from the shrunken channel.
+                adminClient.setChannelToken(SHRINKING_CHANNEL_TOKEN);
+                await adminClient.query(deleteProductDocument, { id: TEST_PRODUCT_ID });
+                await awaitRunningJobs(adminClient);
+
+                const docCount = await countVariantDocsInChannel(
+                    shrinkingChannel.id,
+                    TEST_PRODUCT_ID,
+                );
+                expect(docCount).toBe(0);
             });
 
             afterAll(() => {

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -55,6 +55,7 @@ import {
     deleteAssetDocument,
     deleteProductDocument,
     deleteProductVariantDocument,
+    getProductWithVariantsDocument,
     removeProductFromChannelDocument,
     removeProductVariantFromChannelDocument,
     updateAssetDocument,
@@ -64,7 +65,6 @@ import {
     updateTaxRateDocument,
 } from './graphql/shared-definitions';
 import { searchProductsShopDocument } from './graphql/shop-definitions';
-
 
 
 const { searchBackend } = require('./constants');
@@ -1256,6 +1256,123 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
                 );
             });
         });
+
+        describe('multiple currency handling', () => {
+          
+            const MULTIPLE_CURRENCY_CHANNEL_TOKEN = 'multiple-currency-channel-token';
+            let multipleCurrencyChannel: ChannelFragment;
+
+            beforeAll(async () => {
+                const { createChannel } = await adminClient.query(createChannelDocument, {
+                    input: {
+                        code: 'multiple-currency-channel',
+                        token: MULTIPLE_CURRENCY_CHANNEL_TOKEN,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.GBP,
+                        availableCurrencyCodes: [CurrencyCode.GBP, CurrencyCode.EUR],
+                        pricesIncludeTax: true,
+                        defaultTaxZoneId: 'T_2',
+                        defaultShippingZoneId: 'T_1',
+                    },
+                });
+                multipleCurrencyChannel = createChannel as ChannelFragment;
+
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: { channelId: multipleCurrencyChannel.id, productIds: ['T_3', 'T_4'] },
+                });
+                await awaitRunningJobs(adminClient);
+
+                const { product: productT3 } = await adminClient.query(
+                    getProductWithVariantsDocument,
+                    { id: 'T_3' },
+                );
+                const { product: productT4 } = await adminClient.query(
+                    getProductWithVariantsDocument,
+                    { id: 'T_4' },
+                );
+
+                adminClient.setChannelToken(MULTIPLE_CURRENCY_CHANNEL_TOKEN);
+                await adminClient.query(updateProductVariantsDocument, {
+                    input: [
+                        ...productT3!.variants.map((v, idx) => ({
+                            id: v.id,
+                            prices: [{ currencyCode: CurrencyCode.EUR, price: 1000 + idx }],
+                        })),
+                        ...productT4!.variants.map((v,idx) => ({
+                            id: v.id,
+                            prices: [{ currencyCode: CurrencyCode.EUR, price: 500 + idx }],
+                        })),
+                    ],
+                });
+
+                await adminClient.query(reindexDocument);
+                await awaitRunningJobs(adminClient);
+            });
+
+            it('lookup product', async() => {
+                adminClient.setChannelToken(MULTIPLE_CURRENCY_CHANNEL_TOKEN);
+                const { search } = await doAdminSearchQuery(adminClient, { groupByProduct: true });
+                expect(search.items.map(i => i.productId).sort()).toEqual(['T_3', 'T_4']);
+            })
+
+            it('return GBP by default', async() => {
+                shopClient.setChannelToken(MULTIPLE_CURRENCY_CHANNEL_TOKEN);
+                const result = await shopClient.query(searchGetPricesDocumentWithID, {
+                    input: {
+                        groupByProduct: true,
+                        take: 2
+                    },
+                });
+                expect(result.search.items.find(item => item.productId === "T_4")).toEqual(
+                    {
+                        "productId":"T_4",
+                        "currencyCode": "GBP",
+                        "price":{"min":7896,"max":13435},
+                        "priceWithTax":{"min":11844,"max":20153}
+                    }
+                );
+                expect(result.search.items.find(item => item.productId === "T_3")).toEqual(
+                    {
+                        "productId":"T_3",
+                        "currencyCode": "GBP",
+                        "price":{"min":93120,"max":109995},
+                        "priceWithTax":{"min":139680,"max":164993}
+                    }
+                );
+            })
+
+            it('return EUR when requested', async () => {
+                shopClient.setChannelToken(MULTIPLE_CURRENCY_CHANNEL_TOKEN);
+                const result = await shopClient.query(
+                    searchGetPricesDocumentWithID,
+                    {
+                        input: {
+                            groupByProduct: true,
+                            take: 2,
+                        },
+                    },
+                    { currencyCode: CurrencyCode.EUR },
+                );
+                expect(result.search.items.find(item => item.productId === 'T_3')).toEqual({
+                    productId: 'T_3',
+                    currencyCode: "EUR",
+                    price: { min: 667, max: 669 },
+                    priceWithTax: { min: 1000, max: 1003 },
+                });
+                expect(result.search.items.find(item => item.productId === 'T_4')).toEqual({
+                    productId: 'T_4',
+                    currencyCode: "EUR",
+                    price: { min: 333, max: 335 },
+                    priceWithTax: { min: 500, max: 502 },
+                });
+            });
+
+            afterAll(async() => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            })
+        });
     });
 
     describe('customMappings', () => {
@@ -1299,6 +1416,7 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
 
         // https://github.com/vendurehq/vendure/issues/1638
         it('hydrates variant custom field relation', async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
             await adminClient.query(updateProductVariantsDocument, {
                 input: [
                     {
@@ -1648,6 +1766,35 @@ export const searchGetPricesDocument = graphql(`
     query SearchGetPrices($input: SearchInput!) {
         search(input: $input) {
             items {
+                price {
+                    ... on PriceRange {
+                        min
+                        max
+                    }
+                    ... on SinglePrice {
+                        value
+                    }
+                }
+                priceWithTax {
+                    ... on PriceRange {
+                        min
+                        max
+                    }
+                    ... on SinglePrice {
+                        value
+                    }
+                }
+            }
+        }
+    }
+`);
+
+export const searchGetPricesDocumentWithID = graphql(`
+    query SearchGetPrices($input: SearchInput!) {
+        search(input: $input) {
+            items {
+                productId
+                currencyCode
                 price {
                     ... on PriceRange {
                         min

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -93,6 +93,7 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
                 ElasticsearchPlugin.init({
                     indexPrefix: INDEX_PREFIX,
                     adapter: buildAdapterForBackend(),
+                    indexCurrencyCode: true,
                     hydrateProductVariantRelations: ['customFields.material', 'stockLevels'],
                     customProductVariantMappings: {
                         inStock: {

--- a/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.spec.ts
@@ -247,7 +247,14 @@ describe('buildElasticBody()', () => {
     });
 
     it('collectionIds', () => {
-        const result = buildElasticBody({ collectionIds: ['1', '2'] }, searchConfig, CHANNEL_ID, LanguageCode.en);
+        const result = buildElasticBody(
+            { collectionIds: ['1', '2'] },
+            searchConfig,
+            CHANNEL_ID,
+            LanguageCode.en,
+            undefined,
+            ctx,
+        );
         expect(result.query).toEqual({
             bool: {
                 filter: [CHANNEL_ID_TERM, LANGUAGE_CODE_TERM, { terms: { collectionIds: ['1', '2'] } }],
@@ -277,6 +284,8 @@ describe('buildElasticBody()', () => {
             searchConfig,
             CHANNEL_ID,
             LanguageCode.en,
+            undefined,
+            ctx,
         );
         expect(result.query).toEqual({
             bool: {

--- a/packages/elasticsearch-plugin/src/build-elastic-body.ts
+++ b/packages/elasticsearch-plugin/src/build-elastic-body.ts
@@ -39,6 +39,9 @@ export function buildElasticBody(
     ensureBoolFilterExists(query);
     query.bool.filter.push({ term: { channelId } });
     query.bool.filter.push({ term: { languageCode } });
+    if (ctx.currencyCode) {
+        query.bool.filter.push({ term: { currencyCode: ctx.currencyCode } });
+    }
 
     if (term) {
         query.bool.must = [

--- a/packages/elasticsearch-plugin/src/indexing/currency-aware-request-context.ts
+++ b/packages/elasticsearch-plugin/src/indexing/currency-aware-request-context.ts
@@ -1,5 +1,5 @@
 import { CurrencyCode } from '@vendure/common/lib/generated-types';
-import { MutableRequestContext } from '@vendure/core';
+import { Channel, MutableRequestContext } from '@vendure/core';
 
 type SerializedCtx = Parameters<typeof MutableRequestContext.deserialize>[0];
 
@@ -19,8 +19,32 @@ export class CurrencyAwareMutableRequestContext extends MutableRequestContext {
         return this.mutatedCurrencyCode ?? super.currencyCode;
     }
 
+    /**
+     * We deliberately reimplement `deserialize` instead of delegating to
+     * `super.deserialize` + `Object.setPrototypeOf`. The previous prototype-swap
+     * trick worked but (a) reads as voodoo at the call site, (b) triggers V8
+     * mega-morphic deopts on hot indexing paths and (c) silently breaks if core
+     * ever moves `RequestContext`'s internal state to private `#` fields, which
+     * cannot be re-parented via `setPrototypeOf`.
+     *
+     * The body mirrors {@link MutableRequestContext.deserialize} exactly — same
+     * field plumbing, same session/date rehydration — so subclass semantics stay
+     * in lockstep with the upstream contract. If core's `deserialize` shape
+     * changes (e.g. a new field on the constructor options), this method needs
+     * to track that change.
+     */
     static deserialize(ctxObject: SerializedCtx): CurrencyAwareMutableRequestContext {
-        const base = MutableRequestContext.deserialize(ctxObject);
-        return Object.setPrototypeOf(base, CurrencyAwareMutableRequestContext.prototype);
+        return new CurrencyAwareMutableRequestContext({
+            req: ctxObject._req,
+            apiType: ctxObject._apiType,
+            channel: new Channel(ctxObject._channel),
+            session: {
+                ...ctxObject._session,
+                expires: ctxObject._session?.expires && new Date(ctxObject._session.expires),
+            },
+            languageCode: ctxObject._languageCode,
+            isAuthorized: ctxObject._isAuthorized,
+            authorizedAsOwnerOnly: ctxObject._authorizedAsOwnerOnly,
+        });
     }
 }

--- a/packages/elasticsearch-plugin/src/indexing/currency-aware-request-context.ts
+++ b/packages/elasticsearch-plugin/src/indexing/currency-aware-request-context.ts
@@ -1,0 +1,26 @@
+import { CurrencyCode } from '@vendure/common/lib/generated-types';
+import { MutableRequestContext } from '@vendure/core';
+
+type SerializedCtx = Parameters<typeof MutableRequestContext.deserialize>[0];
+
+/**
+ * Extends MutableRequestContext with the ability to override the currencyCode
+ * independently from the channel. Used by the search indexer to iterate over
+ * each available currency of a channel without mutating the channel entity.
+ */
+export class CurrencyAwareMutableRequestContext extends MutableRequestContext {
+    private mutatedCurrencyCode?: CurrencyCode;
+
+    setCurrencyCode(currencyCode: CurrencyCode | undefined): void {
+        this.mutatedCurrencyCode = currencyCode;
+    }
+
+    get currencyCode(): CurrencyCode {
+        return this.mutatedCurrencyCode ?? super.currencyCode;
+    }
+
+    static deserialize(ctxObject: SerializedCtx): CurrencyAwareMutableRequestContext {
+        const base = MutableRequestContext.deserialize(ctxObject);
+        return Object.setPrototypeOf(base, CurrencyAwareMutableRequestContext.prototype);
+    }
+}

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -742,15 +742,8 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         const product = await this.connection
             .getRepository(ctx, Product)
             .createQueryBuilder('product')
-            .select([
-                'product.id',
-                'productVariant.id',
-                'productTranslations.languageCode',
-                'productVariantTranslations.languageCode',
-            ])
-            .leftJoin('product.translations', 'productTranslations')
+            .select(['product.id', 'productVariant.id'])
             .leftJoin('product.variants', 'productVariant')
-            .leftJoin('productVariant.translations', 'productVariantTranslations')
             .leftJoin('product.channels', 'channel')
             .where('product.id = :productId', { productId })
             .andWhere('channel.id = :channelId', { channelId: ctx.channelId })
@@ -759,51 +752,19 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         if (!product) return;
 
         Logger.debug(`Deleting 1 Product (id: ${productId})`, loggerCtx);
-        let operations: BulkVariantOperation[] = [];
-        const languageVariants: LanguageCode[] = [];
-        languageVariants.push(...product.translations.map(t => t.languageCode));
-        for (const variant of product.variants)
-            languageVariants.push(...variant.translations.map(t => t.languageCode));
 
-        const uniqueLanguageVariants = unique(languageVariants);
-
+        // Synthetic-product docs (created via createSyntheticProductIndexItem for
+        // products with no variants) are stored with `productVariantId: 0` and the
+        // owning `productId`. A single delete_by_query per channel removes every
+        // synthetic doc — across all currencies and languages — without enumerating
+        // the channel's *current* availableCurrencyCodes. That matters because the
+        // channel's currency set may have shrunk since indexing, which would
+        // otherwise leave orphaned docs for the dropped currencies.
         for (const channel of channels) {
-            const currencyCodes = this.getChannelIndexCurrencies(channel);
-            for (const currencyCode of currencyCodes) {
-                for (const languageCode of uniqueLanguageVariants) {
-                    operations.push({
-                        index: VARIANT_INDEX_NAME,
-                        operation: {
-                            delete: {
-                                _id: this.getId(-product.id, channel.id, languageCode, currencyCode),
-                            },
-                        },
-                    });
-                    if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                        await this.executeBulkOperationsByChunks(
-                            this.options.reindexBulkOperationSizeLimit,
-                            operations,
-                            index,
-                        );
-                        operations = [];
-                    }
-                }
-            }
+            await this.deleteSyntheticDocsForProductInChannel(channel.id, product.id, index);
         }
-        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-        await this.executeBulkOperationsByChunks(
-            this.options.reindexBulkOperationSizeLimit,
-            operations,
-            index,
-        );
 
-        await this.deleteVariantsInternalOperations(
-            product.variants,
-            channels,
-            uniqueLanguageVariants,
-            index,
-        );
+        await this.deleteVariantsInternalOperations(product.variants, channels, index);
 
         return;
     }
@@ -811,44 +772,95 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
     private async deleteVariantsInternalOperations(
         variants: ProductVariant[],
         channels: Channel[],
-        languageVariants: LanguageCode[],
         index = VARIANT_INDEX_NAME,
     ): Promise<void> {
+        if (!variants.length) return;
         Logger.debug(`Deleting ${variants.length} ProductVariants`, loggerCtx);
-        let operations: BulkVariantOperation[] = [];
-        for (const variant of variants) {
-            for (const channel of channels) {
-                const currencyCodes = this.getChannelIndexCurrencies(channel);
-                for (const currencyCode of currencyCodes) {
-                    for (const languageCode of languageVariants) {
-                        operations.push({
-                            index: VARIANT_INDEX_NAME,
-                            operation: {
-                                delete: {
-                                    _id: this.getId(variant.id, channel.id, languageCode, currencyCode),
-                                },
-                            },
-                        });
-                        if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                            // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                            await this.executeBulkOperationsByChunks(
-                                this.options.reindexBulkOperationSizeLimit,
-                                operations,
-                                index,
-                            );
-                            operations = [];
-                        }
-                    }
-                }
+        // Because we can have a huge amount of variants for 1 product, we chunk
+        // the variant id list to keep each delete_by_query body bounded — the
+        // chunk size mirrors the same threshold used for indexing bulk ops.
+        const chunkSize = this.options.reindexBulkOperationSizeLimit;
+        const variantIds = variants.map(v => v.id);
+        for (const channel of channels) {
+            for (let i = 0; i < variantIds.length; i += chunkSize) {
+                const chunk = variantIds.slice(i, i + chunkSize);
+                await this.deleteVariantDocsInChannel(channel.id, chunk, index);
             }
         }
-        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-        await this.executeBulkOperationsByChunks(
-            this.options.reindexBulkOperationSizeLimit,
-            operations,
-            index,
-        );
         return;
+    }
+
+    /**
+     * Removes every (currency × language) doc keyed under the given variants in
+     * the supplied channel via a single `delete_by_query`. Replaces the previous
+     * per-channel/per-currency/per-language bulk-delete fan-out, which would miss
+     * docs whose currency had since been removed from the channel's
+     * `availableCurrencyCodes`.
+     */
+    private async deleteVariantDocsInChannel(
+        channelId: ID,
+        variantIds: ID[],
+        index: string,
+    ): Promise<void> {
+        if (!variantIds.length) return;
+        const fullIndexName = this.options.indexPrefix + index;
+        try {
+            await this.adapter.deleteByQuery({
+                index: fullIndexName,
+                refresh: true,
+                body: {
+                    query: {
+                        bool: {
+                            filter: [
+                                { term: { channelId } },
+                                { terms: { productVariantId: variantIds } },
+                            ],
+                        },
+                    },
+                },
+            });
+        } catch (e: any) {
+            Logger.error(
+                `Error deleting variants [${variantIds.join(', ')}] from channel ${channelId} on index ${fullIndexName}: ${JSON.stringify(e?.body?.error ?? e)}`,
+                loggerCtx,
+            );
+        }
+    }
+
+    /**
+     * Removes the synthetic doc(s) for a product in a channel — the docs created
+     * for products with no variants (see `createSyntheticProductIndexItem`). They
+     * are identifiable by `productVariantId: 0` alongside the owning `productId`.
+     */
+    private async deleteSyntheticDocsForProductInChannel(
+        channelId: ID,
+        productId: ID,
+        index: string,
+    ): Promise<void> {
+        const fullIndexName = this.options.indexPrefix + index;
+        try {
+            await this.adapter.deleteByQuery({
+                index: fullIndexName,
+                refresh: true,
+                body: {
+                    query: {
+                        bool: {
+                            filter: [
+                                { term: { channelId } },
+                                { term: { productId } },
+                                // Synthetic items are the only docs with productVariantId: 0.
+                                { term: { productVariantId: 0 } },
+                            ],
+                        },
+                    },
+                },
+            });
+        } catch (e: any) {
+            Logger.error(
+                `Error deleting synthetic docs for product ${productId} from channel ${channelId} on index ${fullIndexName}: ${JSON.stringify(e?.body?.error ?? e)}`,
+                loggerCtx,
+            );
+        }
     }
 
     private async getProductIdsByVariantIds(variantIds: ID[]): Promise<ID[]> {

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -47,6 +47,7 @@ import {
 } from '../types';
 
 import { CurrencyAwareMutableRequestContext } from './currency-aware-request-context';
+import { buildVariantDocId, resolveChannelIndexCurrencies } from './indexing-id-helpers';
 import { createIndices, getIndexNameByAlias } from './indexing-utils';
 
 export const defaultProductRelations: Array<EntityRelationPaths<Product>> = [
@@ -559,9 +560,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                 v.channels.map(c => c.id).includes(ctx.channelId),
             );
 
-            const currencyCodes = channel.availableCurrencyCodes?.length
-                ? channel.availableCurrencyCodes
-                : [channel.defaultCurrencyCode];
+            const currencyCodes = this.getChannelIndexCurrencies(channel);
 
             for (const currencyCode of currencyCodes) {
                 ctx.setCurrencyCode(currencyCode);
@@ -577,7 +576,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                                     index: VARIANT_INDEX_NAME,
                                     operation: {
                                         update: {
-                                            _id: ElasticsearchIndexerController.getId(
+                                            _id: this.getId(
                                                 variant.id,
                                                 ctx.channelId,
                                                 languageCode,
@@ -616,7 +615,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                                 index: VARIANT_INDEX_NAME,
                                 operation: {
                                     update: {
-                                        _id: ElasticsearchIndexerController.getId(
+                                        _id: this.getId(
                                             -product.id,
                                             ctx.channelId,
                                             languageCode,
@@ -754,21 +753,14 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         const uniqueLanguageVariants = unique(languageVariants);
 
         for (const channel of channels) {
-            const currencyCodes = channel.availableCurrencyCodes?.length
-                ? channel.availableCurrencyCodes
-                : [channel.defaultCurrencyCode];
+            const currencyCodes = this.getChannelIndexCurrencies(channel);
             for (const currencyCode of currencyCodes) {
                 for (const languageCode of uniqueLanguageVariants) {
                     operations.push({
                         index: VARIANT_INDEX_NAME,
                         operation: {
                             delete: {
-                                _id: ElasticsearchIndexerController.getId(
-                                    -product.id,
-                                    channel.id,
-                                    languageCode,
-                                    currencyCode,
-                                ),
+                                _id: this.getId(-product.id, channel.id, languageCode, currencyCode),
                             },
                         },
                     });
@@ -811,21 +803,14 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         let operations: BulkVariantOperation[] = [];
         for (const variant of variants) {
             for (const channel of channels) {
-                const currencyCodes = channel.availableCurrencyCodes?.length
-                    ? channel.availableCurrencyCodes
-                    : [channel.defaultCurrencyCode];
+                const currencyCodes = this.getChannelIndexCurrencies(channel);
                 for (const currencyCode of currencyCodes) {
                     for (const languageCode of languageVariants) {
                         operations.push({
                             index: VARIANT_INDEX_NAME,
                             operation: {
                                 delete: {
-                                    _id: ElasticsearchIndexerController.getId(
-                                        variant.id,
-                                        channel.id,
-                                        languageCode,
-                                        currencyCode,
-                                    ),
+                                    _id: this.getId(variant.id, channel.id, languageCode, currencyCode),
                                 },
                             },
                         });
@@ -1103,12 +1088,22 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         return unique([...variantFacetValueIds, ...productFacetValueIds]);
     }
 
-    private static getId(
+    private getId(
         entityId: ID,
         channelId: ID,
         languageCode: LanguageCode,
         currencyCode: CurrencyCode,
     ): string {
-        return `${channelId.toString()}_${entityId.toString()}_${languageCode}_${currencyCode}`;
+        return buildVariantDocId(
+            this.options.indexCurrencyCode,
+            entityId,
+            channelId,
+            languageCode,
+            currencyCode,
+        );
+    }
+
+    private getChannelIndexCurrencies(channel: Channel): CurrencyCode[] {
+        return resolveChannelIndexCurrencies(this.options.indexCurrencyCode, channel);
     }
 }

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -49,6 +49,7 @@ import {
 import { CurrencyAwareMutableRequestContext } from './currency-aware-request-context';
 import { buildVariantDocId, resolveChannelIndexCurrencies } from './indexing-id-helpers';
 import { createIndices, getIndexNameByAlias } from './indexing-utils';
+import { shouldSkipVariantForCurrency } from './variant-price-utils';
 
 export const defaultProductRelations: Array<EntityRelationPaths<Product>> = [
     'featuredAsset',
@@ -66,6 +67,7 @@ export const defaultVariantRelations: Array<EntityRelationPaths<ProductVariant>>
     'taxCategory',
     'channels',
     'channels.defaultTaxZone',
+    'productVariantPrices',
 ];
 
 export interface ReindexMessageResponse {
@@ -571,6 +573,19 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                 for (const languageCode of uniqueLanguageVariants) {
                     if (variantsInChannel.length) {
                         for (const variant of variantsInChannel) {
+                            // Skip variants with no explicit ProductVariantPrice in the
+                            // current (channel, currency) pair: without this guard,
+                            // applyChannelPriceAndTax falls back to a zero `listPrice` and we
+                            // would index a phantom `price: 0` document that pollutes
+                            // `sort: { price: ASC }` and surfaces unpriced variants in
+                            // currency-filtered searches.
+                            if (shouldSkipVariantForCurrency(variant, ctx.channelId, currencyCode)) {
+                                Logger.debug(
+                                    `Skipping variant ${variant.id} for ${currencyCode}: no ProductVariantPrice in this channel`,
+                                    loggerCtx,
+                                );
+                                continue;
+                            }
                             operations.push(
                                 {
                                     index: VARIANT_INDEX_NAME,

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -560,43 +560,87 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
 
         const uniqueLanguageVariants = unique(languageVariants);
         const originalChannel = ctx.channel;
-        for (const channel of product.channels) {
-            ctx.setChannel(channel);
-            const variantsInChannel = updatedProductVariants.filter(v =>
-                v.channels.map(c => c.id).includes(ctx.channelId),
-            );
+        // The same `ctx` instance is reused across products in `updateProductsOperations`,
+        // so any exception inside the per-channel/per-currency loop must NOT leak a
+        // stale `mutatedCurrencyCode` or `channel` onto the shared context. `finally`
+        // guarantees the resets run even on the throwing path.
+        try {
+            for (const channel of product.channels) {
+                ctx.setChannel(channel);
+                const variantsInChannel = updatedProductVariants.filter(v =>
+                    v.channels.map(c => c.id).includes(ctx.channelId),
+                );
 
-            const currencyCodes = this.getChannelIndexCurrencies(channel);
+                const currencyCodes = this.getChannelIndexCurrencies(channel);
 
-            for (const currencyCode of currencyCodes) {
-                ctx.setCurrencyCode(currencyCode);
+                for (const currencyCode of currencyCodes) {
+                    ctx.setCurrencyCode(currencyCode);
 
-                for (const variant of variantsInChannel)
-                    await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
+                    for (const variant of variantsInChannel)
+                        await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
 
-                for (const languageCode of uniqueLanguageVariants) {
-                    if (variantsInChannel.length) {
-                        for (const variant of variantsInChannel) {
-                            // Skip variants with no explicit ProductVariantPrice in the
-                            // current (channel, currency) pair: without this guard,
-                            // applyChannelPriceAndTax falls back to a zero `listPrice` and we
-                            // would index a phantom `price: 0` document that pollutes
-                            // `sort: { price: ASC }` and surfaces unpriced variants in
-                            // currency-filtered searches.
-                            if (shouldSkipVariantForCurrency(variant, ctx.channelId, currencyCode)) {
-                                Logger.debug(
-                                    `Skipping variant ${variant.id} for ${currencyCode}: no ProductVariantPrice in this channel`,
-                                    loggerCtx,
+                    for (const languageCode of uniqueLanguageVariants) {
+                        if (variantsInChannel.length) {
+                            for (const variant of variantsInChannel) {
+                                // Skip variants with no explicit ProductVariantPrice in the
+                                // current (channel, currency) pair: without this guard,
+                                // applyChannelPriceAndTax falls back to a zero `listPrice` and we
+                                // would index a phantom `price: 0` document that pollutes
+                                // `sort: { price: ASC }` and surfaces unpriced variants in
+                                // currency-filtered searches.
+                                if (shouldSkipVariantForCurrency(variant, ctx.channelId, currencyCode)) {
+                                    Logger.debug(
+                                        `Skipping variant ${variant.id} for ${currencyCode}: no ProductVariantPrice in this channel`,
+                                        loggerCtx,
+                                    );
+                                    continue;
+                                }
+                                operations.push(
+                                    {
+                                        index: VARIANT_INDEX_NAME,
+                                        operation: {
+                                            update: {
+                                                _id: this.getId(
+                                                    variant.id,
+                                                    ctx.channelId,
+                                                    languageCode,
+                                                    currencyCode,
+                                                ),
+                                            },
+                                        },
+                                    },
+                                    {
+                                        index: VARIANT_INDEX_NAME,
+                                        operation: {
+                                            doc: await this.createVariantIndexItem(
+                                                variant,
+                                                variantsInChannel,
+                                                ctx,
+                                                languageCode,
+                                            ),
+                                            doc_as_upsert: true,
+                                        },
+                                    },
                                 );
-                                continue;
+
+                                if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
+                                    // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+                                    await this.executeBulkOperationsByChunks(
+                                        this.options.reindexBulkOperationSizeLimit,
+                                        operations,
+                                        index,
+                                    );
+                                    operations = [];
+                                }
                             }
+                        } else {
                             operations.push(
                                 {
                                     index: VARIANT_INDEX_NAME,
                                     operation: {
                                         update: {
                                             _id: this.getId(
-                                                variant.id,
+                                                -product.id,
                                                 ctx.channelId,
                                                 languageCode,
                                                 currencyCode,
@@ -607,9 +651,8 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                                 {
                                     index: VARIANT_INDEX_NAME,
                                     operation: {
-                                        doc: await this.createVariantIndexItem(
-                                            variant,
-                                            variantsInChannel,
+                                        doc: await this.createSyntheticProductIndexItem(
+                                            product,
                                             ctx,
                                             languageCode,
                                         ),
@@ -617,59 +660,23 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                                     },
                                 },
                             );
-
-                            if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                                // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                                await this.executeBulkOperationsByChunks(
-                                    this.options.reindexBulkOperationSizeLimit,
-                                    operations,
-                                    index,
-                                );
-                                operations = [];
-                            }
                         }
-                    } else {
-                        operations.push(
-                            {
-                                index: VARIANT_INDEX_NAME,
-                                operation: {
-                                    update: {
-                                        _id: this.getId(
-                                            -product.id,
-                                            ctx.channelId,
-                                            languageCode,
-                                            currencyCode,
-                                        ),
-                                    },
-                                },
-                            },
-                            {
-                                index: VARIANT_INDEX_NAME,
-                                operation: {
-                                    doc: await this.createSyntheticProductIndexItem(
-                                        product,
-                                        ctx,
-                                        languageCode,
-                                    ),
-                                    doc_as_upsert: true,
-                                },
-                            },
-                        );
-                    }
-                    if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                        await this.executeBulkOperationsByChunks(
-                            this.options.reindexBulkOperationSizeLimit,
-                            operations,
-                            index,
-                        );
-                        operations = [];
+                        if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
+                            // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+                            await this.executeBulkOperationsByChunks(
+                                this.options.reindexBulkOperationSizeLimit,
+                                operations,
+                                index,
+                            );
+                            operations = [];
+                        }
                     }
                 }
             }
+        } finally {
             ctx.setCurrencyCode(undefined);
+            ctx.setChannel(originalChannel);
         }
-        ctx.setChannel(originalChannel);
 
         // Because we can have a huge amount of variant for 1 product, we also chunk update operations
         await this.executeBulkOperationsByChunks(

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -49,7 +49,11 @@ import {
 import { CurrencyAwareMutableRequestContext } from './currency-aware-request-context';
 import { buildVariantDocId, resolveChannelIndexCurrencies } from './indexing-id-helpers';
 import { createIndices, getIndexNameByAlias } from './indexing-utils';
-import { shouldSkipVariantForCurrency } from './variant-price-utils';
+import {
+    shouldSkipVariantForCurrency,
+    snapshotProductPriceAggregates,
+    snapshotVariantPrice,
+} from './variant-price-utils';
 
 export const defaultProductRelations: Array<EntityRelationPaths<Product>> = [
     'featuredAsset',
@@ -933,6 +937,14 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         languageCode: LanguageCode,
     ): Promise<VariantIndexItem> {
         try {
+            // Pin the variant + product price aggregates upfront. `applyChannelPriceAndTax`
+            // mutates the same variant instances in place across (channel, currency)
+            // iterations in `updateProductsOperationsOnly`; snapshotting before any
+            // awaitable work ensures the produced index item reflects the state at
+            // entry, even if a future refactor defers bulk-op composition.
+            const variantSnapshot = snapshotVariantPrice(v);
+            const productPriceSnapshot = snapshotProductPriceAggregates(variants);
+
             const productAsset = v.product.featuredAsset;
             const variantAsset = v.featuredAsset;
             const productTranslation = this.getTranslation(v.product, languageCode);
@@ -946,8 +958,6 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                 ],
                 [] as Array<Translation<Collection>>,
             );
-            const prices = variants.map(variant => variant.price);
-            const pricesWithTax = variants.map(variant => variant.priceWithTax);
 
             const item: VariantIndexItem = {
                 channelId: ctx.channelId,
@@ -966,9 +976,9 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                 productVariantPreviewFocalPoint: variantAsset
                     ? variantAsset.focalPoint || undefined
                     : undefined,
-                price: v.price,
-                priceWithTax: v.priceWithTax,
-                currencyCode: v.currencyCode,
+                price: variantSnapshot.price,
+                priceWithTax: variantSnapshot.priceWithTax,
+                currencyCode: variantSnapshot.currencyCode,
                 description: productTranslation.description,
                 facetIds: this.getFacetIds([v]),
                 channelIds: v.channels.map(c => c.id),
@@ -977,10 +987,10 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                 collectionSlugs: collectionTranslations.map(c => c.slug),
                 enabled: v.enabled && v.product.enabled,
                 productEnabled: variants.some(variant => variant.enabled) && v.product.enabled,
-                productPriceMin: Math.min(...prices),
-                productPriceMax: Math.max(...prices),
-                productPriceWithTaxMin: Math.min(...pricesWithTax),
-                productPriceWithTaxMax: Math.max(...pricesWithTax),
+                productPriceMin: Math.min(...productPriceSnapshot.prices),
+                productPriceMax: Math.max(...productPriceSnapshot.prices),
+                productPriceWithTaxMin: Math.min(...productPriceSnapshot.pricesWithTax),
+                productPriceWithTaxMax: Math.max(...productPriceSnapshot.pricesWithTax),
                 productFacetIds: this.getFacetIds(variants),
                 productFacetValueIds: this.getFacetValueIds(variants),
                 productCollectionIds: unique(

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -1,6 +1,7 @@
 import type { SearchClientAdapter } from '../adapter';
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { CurrencyCode } from '@vendure/common/lib/generated-types';
 import { unique } from '@vendure/common/lib/unique';
 import {
     Asset,
@@ -16,7 +17,6 @@ import {
     InternalServerError,
     LanguageCode,
     Logger,
-    MutableRequestContext,
     Product,
     ProductPriceApplicator,
     ProductVariant,
@@ -46,6 +46,7 @@ import {
     VariantIndexItem,
 } from '../types';
 
+import { CurrencyAwareMutableRequestContext } from './currency-aware-request-context';
 import { createIndices, getIndexNameByAlias } from './indexing-utils';
 
 export const defaultProductRelations: Array<EntityRelationPaths<Product>> = [
@@ -120,7 +121,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
      * Updates the search index only for the affected product.
      */
     async updateProduct({ ctx: rawContext, productId }: UpdateProductMessageData): Promise<boolean> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         await this.updateProductsInternal(ctx, [productId]);
         return true;
     }
@@ -141,7 +142,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         productId,
         channelId,
     }: ProductChannelMessageData): Promise<boolean> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         await this.updateProductsInternal(ctx, [productId]);
         return true;
     }
@@ -154,7 +155,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         productId,
         channelId,
     }: ProductChannelMessageData): Promise<boolean> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         await this.updateProductsInternal(ctx, [productId]);
         return true;
     }
@@ -165,7 +166,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         channelId,
     }: VariantChannelMessageData): Promise<boolean> {
         const productIds = await this.getProductIdsByVariantIds([productVariantId]);
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         await this.updateProductsInternal(ctx, productIds);
         return true;
     }
@@ -176,7 +177,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         channelId,
     }: VariantChannelMessageData): Promise<boolean> {
         const productIds = await this.getProductIdsByVariantIds([productVariantId]);
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         await this.updateProductsInternal(ctx, productIds);
         return true;
     }
@@ -185,7 +186,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
      * Updates the search index only for the affected entities.
      */
     async updateVariants({ ctx: rawContext, variantIds }: UpdateVariantMessageData): Promise<boolean> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         return this.asyncQueue.push(async () => {
             const productIds = await this.getProductIdsByVariantIds(variantIds);
             await this.updateProductsInternal(ctx, productIds);
@@ -194,7 +195,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
     }
 
     async deleteVariants({ ctx: rawContext, variantIds }: UpdateVariantMessageData): Promise<boolean> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         const productIds = await this.getProductIdsByVariantIds(variantIds);
         for (const productId of productIds) {
             await this.updateProductsInternal(ctx, [productId]);
@@ -206,7 +207,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         ctx: rawContext,
         ids,
     }: UpdateVariantsByIdMessageData): Observable<ReindexMessageResponse> {
-        const ctx = MutableRequestContext.deserialize(rawContext);
+        const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
         return asyncObservable(async observer => {
             return this.asyncQueue.push(async () => {
                 const timeStart = Date.now();
@@ -237,7 +238,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         return asyncObservable(async observer => {
             return this.asyncQueue.push(async () => {
                 const timeStart = Date.now();
-                const ctx = MutableRequestContext.deserialize(rawContext);
+                const ctx = CurrencyAwareMutableRequestContext.deserialize(rawContext);
 
                 const reindexTempName = new Date().getTime();
                 const variantIndexName = `${this.options.indexPrefix}${VARIANT_INDEX_NAME}`;
@@ -421,7 +422,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         return failures1.length === 0 && failures2.length === 0;
     }
 
-    private async updateProductsInternal(ctx: MutableRequestContext, productIds: ID[]) {
+    private async updateProductsInternal(ctx: CurrencyAwareMutableRequestContext, productIds: ID[]) {
         await this.updateProductsOperations(ctx, productIds);
     }
 
@@ -501,7 +502,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
     }
 
     private async updateProductsOperationsOnly(
-        ctx: MutableRequestContext,
+        ctx: CurrencyAwareMutableRequestContext,
         productId: ID,
         index = VARIANT_INDEX_NAME,
     ): Promise<void> {
@@ -557,21 +558,69 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
             const variantsInChannel = updatedProductVariants.filter(v =>
                 v.channels.map(c => c.id).includes(ctx.channelId),
             );
-            for (const variant of variantsInChannel)
-                await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
 
-            for (const languageCode of uniqueLanguageVariants) {
-                if (variantsInChannel.length) {
-                    for (const variant of variantsInChannel) {
+            const currencyCodes = channel.availableCurrencyCodes?.length
+                ? channel.availableCurrencyCodes
+                : [channel.defaultCurrencyCode];
+
+            for (const currencyCode of currencyCodes) {
+                ctx.setCurrencyCode(currencyCode);
+
+                for (const variant of variantsInChannel)
+                    await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
+
+                for (const languageCode of uniqueLanguageVariants) {
+                    if (variantsInChannel.length) {
+                        for (const variant of variantsInChannel) {
+                            operations.push(
+                                {
+                                    index: VARIANT_INDEX_NAME,
+                                    operation: {
+                                        update: {
+                                            _id: ElasticsearchIndexerController.getId(
+                                                variant.id,
+                                                ctx.channelId,
+                                                languageCode,
+                                                currencyCode,
+                                            ),
+                                        },
+                                    },
+                                },
+                                {
+                                    index: VARIANT_INDEX_NAME,
+                                    operation: {
+                                        doc: await this.createVariantIndexItem(
+                                            variant,
+                                            variantsInChannel,
+                                            ctx,
+                                            languageCode,
+                                        ),
+                                        doc_as_upsert: true,
+                                    },
+                                },
+                            );
+
+                            if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
+                                // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+                                await this.executeBulkOperationsByChunks(
+                                    this.options.reindexBulkOperationSizeLimit,
+                                    operations,
+                                    index,
+                                );
+                                operations = [];
+                            }
+                        }
+                    } else {
                         operations.push(
                             {
                                 index: VARIANT_INDEX_NAME,
                                 operation: {
                                     update: {
                                         _id: ElasticsearchIndexerController.getId(
-                                            variant.id,
+                                            -product.id,
                                             ctx.channelId,
                                             languageCode,
+                                            currencyCode,
                                         ),
                                     },
                                 },
@@ -579,9 +628,8 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                             {
                                 index: VARIANT_INDEX_NAME,
                                 operation: {
-                                    doc: await this.createVariantIndexItem(
-                                        variant,
-                                        variantsInChannel,
+                                    doc: await this.createSyntheticProductIndexItem(
+                                        product,
                                         ctx,
                                         languageCode,
                                     ),
@@ -589,50 +637,19 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                                 },
                             },
                         );
-
-                        if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                            // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                            await this.executeBulkOperationsByChunks(
-                                this.options.reindexBulkOperationSizeLimit,
-                                operations,
-                                index,
-                            );
-                            operations = [];
-                        }
                     }
-                } else {
-                    operations.push(
-                        {
-                            index: VARIANT_INDEX_NAME,
-                            operation: {
-                                update: {
-                                    _id: ElasticsearchIndexerController.getId(
-                                        -product.id,
-                                        ctx.channelId,
-                                        languageCode,
-                                    ),
-                                },
-                            },
-                        },
-                        {
-                            index: VARIANT_INDEX_NAME,
-                            operation: {
-                                doc: await this.createSyntheticProductIndexItem(product, ctx, languageCode),
-                                doc_as_upsert: true,
-                            },
-                        },
-                    );
-                }
-                if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                    // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                    await this.executeBulkOperationsByChunks(
-                        this.options.reindexBulkOperationSizeLimit,
-                        operations,
-                        index,
-                    );
-                    operations = [];
+                    if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
+                        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+                        await this.executeBulkOperationsByChunks(
+                            this.options.reindexBulkOperationSizeLimit,
+                            operations,
+                            index,
+                        );
+                        operations = [];
+                    }
                 }
             }
+            ctx.setCurrencyCode(undefined);
         }
         ctx.setChannel(originalChannel);
 
@@ -646,7 +663,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         return;
     }
 
-    private async updateProductsOperations(ctx: MutableRequestContext, productIds: ID[]): Promise<void> {
+    private async updateProductsOperations(ctx: CurrencyAwareMutableRequestContext, productIds: ID[]): Promise<void> {
         Logger.debug(`Updating ${productIds.length} Products`, loggerCtx);
         for (const productId of productIds) {
             await this.deleteProductOperations(ctx, productId);
@@ -704,7 +721,7 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
             this.connection.rawConnection
                 .getRepository(Channel)
                 .createQueryBuilder('channel')
-                .select('channel.id')
+                .select(['channel.id', 'channel.defaultCurrencyCode', 'channel.availableCurrencyCodes'])
                 .getMany(),
         );
 
@@ -736,63 +753,21 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
 
         const uniqueLanguageVariants = unique(languageVariants);
 
-        for (const { id: channelId } of channels) {
-            for (const languageCode of uniqueLanguageVariants) {
-                operations.push({
-                    index: VARIANT_INDEX_NAME,
-                    operation: {
-                        delete: {
-                            _id: ElasticsearchIndexerController.getId(-product.id, channelId, languageCode),
-                        },
-                    },
-                });
-                if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
-                    // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-                    await this.executeBulkOperationsByChunks(
-                        this.options.reindexBulkOperationSizeLimit,
-                        operations,
-                        index,
-                    );
-                    operations = [];
-                }
-            }
-        }
-        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
-        await this.executeBulkOperationsByChunks(
-            this.options.reindexBulkOperationSizeLimit,
-            operations,
-            index,
-        );
-
-        await this.deleteVariantsInternalOperations(
-            product.variants,
-            channels.map(c => c.id),
-            uniqueLanguageVariants,
-            index,
-        );
-
-        return;
-    }
-
-    private async deleteVariantsInternalOperations(
-        variants: ProductVariant[],
-        channelIds: ID[],
-        languageVariants: LanguageCode[],
-        index = VARIANT_INDEX_NAME,
-    ): Promise<void> {
-        Logger.debug(`Deleting ${variants.length} ProductVariants`, loggerCtx);
-        let operations: BulkVariantOperation[] = [];
-        for (const variant of variants) {
-            for (const channelId of channelIds) {
-                for (const languageCode of languageVariants) {
+        for (const channel of channels) {
+            const currencyCodes = channel.availableCurrencyCodes?.length
+                ? channel.availableCurrencyCodes
+                : [channel.defaultCurrencyCode];
+            for (const currencyCode of currencyCodes) {
+                for (const languageCode of uniqueLanguageVariants) {
                     operations.push({
                         index: VARIANT_INDEX_NAME,
                         operation: {
                             delete: {
                                 _id: ElasticsearchIndexerController.getId(
-                                    variant.id,
-                                    channelId,
+                                    -product.id,
+                                    channel.id,
                                     languageCode,
+                                    currencyCode,
                                 ),
                             },
                         },
@@ -805,6 +780,64 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
                             index,
                         );
                         operations = [];
+                    }
+                }
+            }
+        }
+        // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+        await this.executeBulkOperationsByChunks(
+            this.options.reindexBulkOperationSizeLimit,
+            operations,
+            index,
+        );
+
+        await this.deleteVariantsInternalOperations(
+            product.variants,
+            channels,
+            uniqueLanguageVariants,
+            index,
+        );
+
+        return;
+    }
+
+    private async deleteVariantsInternalOperations(
+        variants: ProductVariant[],
+        channels: Channel[],
+        languageVariants: LanguageCode[],
+        index = VARIANT_INDEX_NAME,
+    ): Promise<void> {
+        Logger.debug(`Deleting ${variants.length} ProductVariants`, loggerCtx);
+        let operations: BulkVariantOperation[] = [];
+        for (const variant of variants) {
+            for (const channel of channels) {
+                const currencyCodes = channel.availableCurrencyCodes?.length
+                    ? channel.availableCurrencyCodes
+                    : [channel.defaultCurrencyCode];
+                for (const currencyCode of currencyCodes) {
+                    for (const languageCode of languageVariants) {
+                        operations.push({
+                            index: VARIANT_INDEX_NAME,
+                            operation: {
+                                delete: {
+                                    _id: ElasticsearchIndexerController.getId(
+                                        variant.id,
+                                        channel.id,
+                                        languageCode,
+                                        currencyCode,
+                                    ),
+                                },
+                            },
+                        });
+                        if (operations.length >= this.options.reindexBulkOperationSizeLimit) {
+                            // Because we can have a huge amount of variant for 1 product, we also chunk update operations
+                            await this.executeBulkOperationsByChunks(
+                                this.options.reindexBulkOperationSizeLimit,
+                                operations,
+                                index,
+                            );
+                            operations = [];
+                        }
                     }
                 }
             }
@@ -1070,7 +1103,12 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
         return unique([...variantFacetValueIds, ...productFacetValueIds]);
     }
 
-    private static getId(entityId: ID, channelId: ID, languageCode: LanguageCode): string {
-        return `${channelId.toString()}_${entityId.toString()}_${languageCode}`;
+    private static getId(
+        entityId: ID,
+        channelId: ID,
+        languageCode: LanguageCode,
+        currencyCode: CurrencyCode,
+    ): string {
+        return `${channelId.toString()}_${entityId.toString()}_${languageCode}_${currencyCode}`;
     }
 }

--- a/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.spec.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.spec.ts
@@ -1,0 +1,79 @@
+import { CurrencyCode, LanguageCode } from '@vendure/common/lib/generated-types';
+import { Channel } from '@vendure/core';
+import { describe, expect, it } from 'vitest';
+
+import { buildVariantDocId, resolveChannelIndexCurrencies } from './indexing-id-helpers';
+
+describe('indexing id helpers', () => {
+    describe('buildVariantDocId()', () => {
+        it('returns the legacy 3-part shape when indexCurrencyCode is disabled', () => {
+            const id = buildVariantDocId(false, 7, 2, LanguageCode.en, CurrencyCode.USD);
+            expect(id).toBe('2_7_en');
+        });
+
+        it('returns the 4-part shape including currency when indexCurrencyCode is enabled', () => {
+            const id = buildVariantDocId(true, 7, 2, LanguageCode.en, CurrencyCode.USD);
+            expect(id).toBe('2_7_en_USD');
+        });
+
+        it('handles string ids identically', () => {
+            expect(buildVariantDocId(false, 'v-1', 'c-1', LanguageCode.fr, CurrencyCode.EUR)).toBe(
+                'c-1_v-1_fr',
+            );
+            expect(buildVariantDocId(true, 'v-1', 'c-1', LanguageCode.fr, CurrencyCode.EUR)).toBe(
+                'c-1_v-1_fr_EUR',
+            );
+        });
+
+        it('encodes synthetic (negative) variant ids the same way for both modes', () => {
+            expect(buildVariantDocId(false, -42, 1, LanguageCode.en, CurrencyCode.GBP)).toBe('1_-42_en');
+            expect(buildVariantDocId(true, -42, 1, LanguageCode.en, CurrencyCode.GBP)).toBe(
+                '1_-42_en_GBP',
+            );
+        });
+    });
+
+    describe('resolveChannelIndexCurrencies()', () => {
+        it('returns [defaultCurrencyCode] when indexCurrencyCode is disabled, even if availableCurrencyCodes is non-empty', () => {
+            const channel = new Channel({
+                defaultCurrencyCode: CurrencyCode.USD,
+                availableCurrencyCodes: [CurrencyCode.USD, CurrencyCode.EUR, CurrencyCode.GBP],
+            });
+            expect(resolveChannelIndexCurrencies(false, channel)).toEqual([CurrencyCode.USD]);
+        });
+
+        it('returns [defaultCurrencyCode] when indexCurrencyCode is disabled and availableCurrencyCodes is empty', () => {
+            const channel = new Channel({
+                defaultCurrencyCode: CurrencyCode.USD,
+                availableCurrencyCodes: [],
+            });
+            expect(resolveChannelIndexCurrencies(false, channel)).toEqual([CurrencyCode.USD]);
+        });
+
+        it('returns availableCurrencyCodes when indexCurrencyCode is enabled', () => {
+            const channel = new Channel({
+                defaultCurrencyCode: CurrencyCode.USD,
+                availableCurrencyCodes: [CurrencyCode.USD, CurrencyCode.EUR],
+            });
+            expect(resolveChannelIndexCurrencies(true, channel)).toEqual([
+                CurrencyCode.USD,
+                CurrencyCode.EUR,
+            ]);
+        });
+
+        it('falls back to [defaultCurrencyCode] when indexCurrencyCode is enabled but availableCurrencyCodes is empty', () => {
+            const channel = new Channel({
+                defaultCurrencyCode: CurrencyCode.GBP,
+                availableCurrencyCodes: [],
+            });
+            expect(resolveChannelIndexCurrencies(true, channel)).toEqual([CurrencyCode.GBP]);
+        });
+
+        it('falls back to [defaultCurrencyCode] when indexCurrencyCode is enabled but availableCurrencyCodes is undefined', () => {
+            const channel = new Channel({
+                defaultCurrencyCode: CurrencyCode.GBP,
+            } as Partial<Channel>);
+            expect(resolveChannelIndexCurrencies(true, channel)).toEqual([CurrencyCode.GBP]);
+        });
+    });
+});

--- a/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.spec.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.spec.ts
@@ -72,7 +72,7 @@ describe('indexing id helpers', () => {
         it('falls back to [defaultCurrencyCode] when indexCurrencyCode is enabled but availableCurrencyCodes is undefined', () => {
             const channel = new Channel({
                 defaultCurrencyCode: CurrencyCode.GBP,
-            } as Partial<Channel>);
+            });
             expect(resolveChannelIndexCurrencies(true, channel)).toEqual([CurrencyCode.GBP]);
         });
     });

--- a/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexing-id-helpers.ts
@@ -1,0 +1,42 @@
+import { CurrencyCode } from '@vendure/common/lib/generated-types';
+import { Channel, ID } from '@vendure/core';
+import { LanguageCode } from '@vendure/core';
+
+/**
+ * Builds the Elasticsearch `_id` for a variant document.
+ *
+ * When `indexCurrencyCode` is `false` (the default), the legacy 3-part shape
+ * `{channelId}_{entityId}_{languageCode}` is used so that existing single-currency
+ * deployments do not require a reindex when upgrading. When `true`, the 4-part
+ * shape including `currencyCode` is used to disambiguate per-currency documents.
+ */
+export function buildVariantDocId(
+    indexCurrencyCode: boolean,
+    entityId: ID,
+    channelId: ID,
+    languageCode: LanguageCode,
+    currencyCode: CurrencyCode,
+): string {
+    const base = `${channelId.toString()}_${entityId.toString()}_${languageCode}`;
+    return indexCurrencyCode ? `${base}_${currencyCode}` : base;
+}
+
+/**
+ * Returns the set of currencies that should be indexed for the given channel.
+ *
+ * When `indexCurrencyCode` is disabled, only the channel's `defaultCurrencyCode`
+ * is returned — preserving the pre-multi-currency single-doc behaviour. When
+ * enabled, the channel's full `availableCurrencyCodes` set is returned (falling
+ * back to `[defaultCurrencyCode]` if the channel does not expose an explicit list).
+ */
+export function resolveChannelIndexCurrencies(
+    indexCurrencyCode: boolean,
+    channel: Pick<Channel, 'defaultCurrencyCode' | 'availableCurrencyCodes'>,
+): CurrencyCode[] {
+    if (!indexCurrencyCode) {
+        return [channel.defaultCurrencyCode];
+    }
+    return channel.availableCurrencyCodes?.length
+        ? channel.availableCurrencyCodes
+        : [channel.defaultCurrencyCode];
+}

--- a/packages/elasticsearch-plugin/src/indexing/variant-price-utils.spec.ts
+++ b/packages/elasticsearch-plugin/src/indexing/variant-price-utils.spec.ts
@@ -2,7 +2,12 @@ import { CurrencyCode } from '@vendure/common/lib/generated-types';
 import { ProductVariant, ProductVariantPrice } from '@vendure/core';
 import { describe, expect, it } from 'vitest';
 
-import { hasExplicitVariantPrice, shouldSkipVariantForCurrency } from './variant-price-utils';
+import {
+    hasExplicitVariantPrice,
+    shouldSkipVariantForCurrency,
+    snapshotProductPriceAggregates,
+    snapshotVariantPrice,
+} from './variant-price-utils';
 
 function variant(prices: Array<Partial<ProductVariantPrice>>, listPrice = 0): ProductVariant {
     return {
@@ -70,6 +75,72 @@ describe('variant-price-utils', () => {
         it('does not skip when both a matching price row and a non-zero listPrice are present', () => {
             const v = variant([{ channelId: 2, currencyCode: CurrencyCode.EUR }], 1500);
             expect(shouldSkipVariantForCurrency(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+    });
+
+    describe('snapshotVariantPrice()', () => {
+        it('captures the variant price fields by value', () => {
+            const v = {
+                price: 1500,
+                priceWithTax: 1800,
+                currencyCode: CurrencyCode.EUR,
+            } as unknown as ProductVariant;
+            const snap = snapshotVariantPrice(v);
+            expect(snap).toEqual({
+                price: 1500,
+                priceWithTax: 1800,
+                currencyCode: CurrencyCode.EUR,
+            });
+        });
+
+        it('is decoupled from later mutations of the source variant', () => {
+            const v = {
+                price: 1500,
+                priceWithTax: 1800,
+                currencyCode: CurrencyCode.EUR,
+            } as unknown as ProductVariant;
+            const snap = snapshotVariantPrice(v);
+            // Simulate a subsequent applyChannelPriceAndTax overwriting the same
+            // variant instance for the next currency iteration.
+            v.price = 9999;
+            v.priceWithTax = 9999;
+            v.currencyCode = CurrencyCode.GBP;
+            expect(snap).toEqual({
+                price: 1500,
+                priceWithTax: 1800,
+                currencyCode: CurrencyCode.EUR,
+            });
+        });
+    });
+
+    describe('snapshotProductPriceAggregates()', () => {
+        it('captures per-variant price + priceWithTax arrays', () => {
+            const variants = [
+                { price: 100, priceWithTax: 120 },
+                { price: 200, priceWithTax: 240 },
+                { price: 300, priceWithTax: 360 },
+            ] as unknown as ProductVariant[];
+            const snap = snapshotProductPriceAggregates(variants);
+            expect(snap.prices).toEqual([100, 200, 300]);
+            expect(snap.pricesWithTax).toEqual([120, 240, 360]);
+        });
+
+        it('is decoupled from later mutations of the source variants', () => {
+            const variants = [
+                { price: 100, priceWithTax: 120 },
+                { price: 200, priceWithTax: 240 },
+            ] as unknown as ProductVariant[];
+            const snap = snapshotProductPriceAggregates(variants);
+            // Simulate the next currency iteration overwriting the same instances.
+            variants[0].price = 999;
+            variants[1].priceWithTax = 999;
+            expect(snap.prices).toEqual([100, 200]);
+            expect(snap.pricesWithTax).toEqual([120, 240]);
+        });
+
+        it('returns empty arrays when no variants are passed', () => {
+            const snap = snapshotProductPriceAggregates([]);
+            expect(snap).toEqual({ prices: [], pricesWithTax: [] });
         });
     });
 });

--- a/packages/elasticsearch-plugin/src/indexing/variant-price-utils.spec.ts
+++ b/packages/elasticsearch-plugin/src/indexing/variant-price-utils.spec.ts
@@ -1,0 +1,75 @@
+import { CurrencyCode } from '@vendure/common/lib/generated-types';
+import { ProductVariant, ProductVariantPrice } from '@vendure/core';
+import { describe, expect, it } from 'vitest';
+
+import { hasExplicitVariantPrice, shouldSkipVariantForCurrency } from './variant-price-utils';
+
+function variant(prices: Array<Partial<ProductVariantPrice>>, listPrice = 0): ProductVariant {
+    return {
+        productVariantPrices: prices as ProductVariantPrice[],
+        listPrice,
+    } as unknown as ProductVariant;
+}
+
+describe('variant-price-utils', () => {
+    describe('hasExplicitVariantPrice()', () => {
+        it('returns true when a price row matches both channel and currency', () => {
+            const v = variant([
+                { channelId: 2, currencyCode: CurrencyCode.GBP },
+                { channelId: 2, currencyCode: CurrencyCode.EUR },
+            ]);
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(true);
+        });
+
+        it('returns false when currency matches but channel does not', () => {
+            const v = variant([{ channelId: 1, currencyCode: CurrencyCode.EUR }]);
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+
+        it('returns false when channel matches but currency does not', () => {
+            const v = variant([{ channelId: 2, currencyCode: CurrencyCode.GBP }]);
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+
+        it('handles string channel ids via idsAreEqual', () => {
+            const v = variant([{ channelId: '2', currencyCode: CurrencyCode.EUR }]);
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(true);
+        });
+
+        it('returns false when productVariantPrices is empty', () => {
+            const v = variant([]);
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+
+        it('returns false when productVariantPrices is undefined', () => {
+            const v = { productVariantPrices: undefined } as unknown as ProductVariant;
+            expect(hasExplicitVariantPrice(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+    });
+
+    describe('shouldSkipVariantForCurrency()', () => {
+        it('skips when no matching price row AND listPrice is zero', () => {
+            const v = variant([{ channelId: 2, currencyCode: CurrencyCode.GBP }], 0);
+            expect(shouldSkipVariantForCurrency(v, 2, CurrencyCode.EUR)).toBe(true);
+        });
+
+        it('does not skip when an explicit price row exists, even if listPrice is zero', () => {
+            // listPrice may be 0 transiently (e.g. tax strategy quirks); the explicit
+            // ProductVariantPrice row is the source of truth that the variant is "priced".
+            const v = variant([{ channelId: 2, currencyCode: CurrencyCode.EUR, price: 0 }], 0);
+            expect(shouldSkipVariantForCurrency(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+
+        it('does not skip when listPrice is non-zero, even if no matching price row', () => {
+            // Defensive: should never happen if applyChannelPriceAndTax behaves as
+            // documented, but the guard remains strict — non-zero price is always indexed.
+            const v = variant([], 1500);
+            expect(shouldSkipVariantForCurrency(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+
+        it('does not skip when both a matching price row and a non-zero listPrice are present', () => {
+            const v = variant([{ channelId: 2, currencyCode: CurrencyCode.EUR }], 1500);
+            expect(shouldSkipVariantForCurrency(v, 2, CurrencyCode.EUR)).toBe(false);
+        });
+    });
+});

--- a/packages/elasticsearch-plugin/src/indexing/variant-price-utils.ts
+++ b/packages/elasticsearch-plugin/src/indexing/variant-price-utils.ts
@@ -1,0 +1,34 @@
+import { CurrencyCode } from '@vendure/common/lib/generated-types';
+import { ID, idsAreEqual, ProductVariant } from '@vendure/core';
+
+/**
+ * Returns `true` if the given variant has a `ProductVariantPrice` row that matches the
+ * supplied `(channelId, currencyCode)` pair. Used by the indexer to avoid producing a
+ * phantom `price: 0` document when `applyChannelPriceAndTax` falls back to zero because
+ * no price exists for the requested currency in the active channel.
+ */
+export function hasExplicitVariantPrice(
+    variant: Pick<ProductVariant, 'productVariantPrices'>,
+    channelId: ID,
+    currencyCode: CurrencyCode,
+): boolean {
+    return (
+        variant.productVariantPrices?.some(
+            p => p.currencyCode === currencyCode && idsAreEqual(p.channelId, channelId),
+        ) ?? false
+    );
+}
+
+/**
+ * Combines the explicit-price probe with the post-`applyChannelPriceAndTax` state of
+ * the variant: returns `true` only when there is no price row for `(channel, currency)`
+ * AND the applicator has left `listPrice` at `0`. This is the signal that indexing the
+ * variant for the current currency would produce a misleading zero-priced document.
+ */
+export function shouldSkipVariantForCurrency(
+    variant: Pick<ProductVariant, 'productVariantPrices' | 'listPrice'>,
+    channelId: ID,
+    currencyCode: CurrencyCode,
+): boolean {
+    return !hasExplicitVariantPrice(variant, channelId, currencyCode) && variant.listPrice === 0;
+}

--- a/packages/elasticsearch-plugin/src/indexing/variant-price-utils.ts
+++ b/packages/elasticsearch-plugin/src/indexing/variant-price-utils.ts
@@ -2,6 +2,27 @@ import { CurrencyCode } from '@vendure/common/lib/generated-types';
 import { ID, idsAreEqual, ProductVariant } from '@vendure/core';
 
 /**
+ * Eager copy of the price-related fields that `ProductPriceApplicator.applyChannelPriceAndTax`
+ * mutates in place on a `ProductVariant`. The indexer reuses the same variant object
+ * across `(channel, currency)` iterations; taking a snapshot at the moment of use makes
+ * the produced index document immune to subsequent mutations by later iterations.
+ */
+export interface VariantPriceSnapshot {
+    price: number;
+    priceWithTax: number;
+    currencyCode: CurrencyCode;
+}
+
+/**
+ * Snapshot of the per-variant price aggregations consumed when computing
+ * `productPriceMin/Max` and `productPriceWithTaxMin/Max` for the index item.
+ */
+export interface ProductPriceAggregateSnapshot {
+    prices: number[];
+    pricesWithTax: number[];
+}
+
+/**
  * Returns `true` if the given variant has a `ProductVariantPrice` row that matches the
  * supplied `(channelId, currencyCode)` pair. Used by the indexer to avoid producing a
  * phantom `price: 0` document when `applyChannelPriceAndTax` falls back to zero because
@@ -31,4 +52,36 @@ export function shouldSkipVariantForCurrency(
     currencyCode: CurrencyCode,
 ): boolean {
     return !hasExplicitVariantPrice(variant, channelId, currencyCode) && variant.listPrice === 0;
+}
+
+/**
+ * Captures the price-related fields of a single variant *as they stand right now*.
+ * Decouples the indexed document from any later in-place mutation of the same
+ * variant instance (typically by the next currency iteration's
+ * `applyChannelPriceAndTax`).
+ */
+export function snapshotVariantPrice(
+    variant: Pick<ProductVariant, 'price' | 'priceWithTax' | 'currencyCode'>,
+): VariantPriceSnapshot {
+    return {
+        price: variant.price,
+        priceWithTax: variant.priceWithTax,
+        currencyCode: variant.currencyCode,
+    };
+}
+
+/**
+ * Captures the per-variant price aggregates needed for the product-level
+ * `productPriceMin/Max` and `productPriceWithTaxMin/Max` fields. Same rationale
+ * as {@link snapshotVariantPrice}: pin the values at the moment of use so that
+ * subsequent mutations on the same array of variant instances cannot leak into
+ * an already-composed index item.
+ */
+export function snapshotProductPriceAggregates(
+    variants: Array<Pick<ProductVariant, 'price' | 'priceWithTax'>>,
+): ProductPriceAggregateSnapshot {
+    return {
+        prices: variants.map(v => v.price),
+        pricesWithTax: variants.map(v => v.priceWithTax),
+    };
 }

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -298,6 +298,23 @@ export interface ElasticsearchOptions {
     bufferUpdates?: boolean;
     /**
      * @description
+     * If set to `true`, the search index will contain separate documents per channel currency,
+     * keyed on `{channelId}_{entityId}_{languageCode}_{currencyCode}`. Each variant is indexed
+     * once per `(channel, languageCode, currencyCode)` triple using the configured
+     * `ProductVariantPriceSelectionStrategy` to resolve the price for the given currency.
+     *
+     * When `false` (the default), the index keeps the 3-part `_id` shape
+     * `{channelId}_{entityId}_{languageCode}` and only the channel's `defaultCurrencyCode`
+     * is indexed — matching the behaviour prior to multi-currency support. This preserves
+     * compatibility for single-currency deployments and avoids a forced reindex on upgrade.
+     *
+     * Enabling this option after upgrade requires a full reindex.
+     *
+     * @default false
+     */
+    indexCurrencyCode?: boolean;
+    /**
+     * @description
      * Additional product relations that will be fetched from DB while reindexing. This can be used
      * in combination with `customProductMappings` to ensure that the required relations are joined
      * before the `product` object is passed to the `valueFn`.
@@ -756,6 +773,7 @@ export const defaultOptions: ElasticsearchRuntimeOptions = {
     customProductMappings: {},
     customProductVariantMappings: {},
     bufferUpdates: false,
+    indexCurrencyCode: false,
     hydrateProductRelations: [],
     hydrateProductVariantRelations: [],
     extendSearchInputType: {},

--- a/packages/elasticsearch-plugin/src/plugin.ts
+++ b/packages/elasticsearch-plugin/src/plugin.ts
@@ -3,6 +3,8 @@ import {
     AssetEvent,
     BUFFER_SEARCH_INDEX_UPDATES,
     CollectionModificationEvent,
+    ConfigService,
+    DefaultProductVariantPriceSelectionStrategy,
     EventBus,
     HealthCheckRegistryService,
     ID,
@@ -114,6 +116,7 @@ export class ElasticsearchPlugin implements OnApplicationBootstrap {
         private elasticsearchIndexService: ElasticsearchIndexService,
         private elasticsearchHealthIndicator: ElasticsearchHealthIndicator,
         private healthCheckRegistryService: HealthCheckRegistryService,
+        private configService: ConfigService,
     ) {}
 
     /**
@@ -135,6 +138,8 @@ export class ElasticsearchPlugin implements OnApplicationBootstrap {
             return;
         }
         Logger.info(`Successfully connected to search backend (${backendLabel})`, loggerCtx);
+
+        this.warnIfCustomPriceStrategyWithMultiCurrencyIndexing();
 
         await this.elasticsearchService.createIndicesIfNotExists();
         this.eventBus.ofType(ProductEvent).subscribe(event => {
@@ -241,5 +246,29 @@ export class ElasticsearchPlugin implements OnApplicationBootstrap {
      */
     private backendLabel(): string {
         return this.elasticsearchService.getBackendLabel();
+    }
+
+    /**
+     * Emits a one-off bootstrap warning when `indexCurrencyCode: true` is paired
+     * with a custom `ProductVariantPriceSelectionStrategy`. The multi-currency
+     * indexer relies on the strategy honouring `ctx.currencyCode` so that each
+     * `(channel, currency)` iteration receives the matching price row; a strategy
+     * that ignores the currency would silently produce identical prices across
+     * currencies in the index. This isn't fatal — hence a warning, not a throw —
+     * but it almost always indicates misconfiguration worth surfacing.
+     */
+    private warnIfCustomPriceStrategyWithMultiCurrencyIndexing(): void {
+        if (!ElasticsearchPlugin.options.indexCurrencyCode) {
+            return;
+        }
+        const strategy = this.configService.catalogOptions.productVariantPriceSelectionStrategy;
+        if (strategy instanceof DefaultProductVariantPriceSelectionStrategy) {
+            return;
+        }
+        Logger.warn(
+            'A custom ProductVariantPriceSelectionStrategy is configured together with indexCurrencyCode=true — ' +
+                'verify it honours ctx.currencyCode, otherwise per-currency search documents may all share the same price.',
+            loggerCtx,
+        );
     }
 }


### PR DESCRIPTION
### Context 

Until now the Elasticsearch index used `${channelId}_${entityId}_${languageCode}` as document ID and only stored the price for the channel's default currency. As a consequence, a channel with `availableCurrencyCodes: [GBP, EUR]` would expose 
GBP-priced variants only — querying it with `currencyCode = EUR` returned the GBP price.

### Changes 

#### Indexing

- New `CurrencyAwareMutableRequestContext` (extends `MutableRequestContext`) that exposes `setCurrencyCode()` and overrides the `currencyCode` getter so the indexing context can switch currency without mutating the active `Channel`.
- `ElasticsearchIndexerController.getId(...)` now takes a `currencyCode` and produces `${channelId}_${entityId}_${languageCode}_${currencyCode}`. One document per (channel × language × currency) instead of one per (channel × language).
- The main indexing loop in `updateProductsInternal` iterates over `channel.availableCurrencyCodes` (fallback to `[channel.defaultCurrencyCode]`). For each currency it calls `ctx.setCurrencyCode(currencyCode)` then `applyChannelPriceAndTax(variant,
 ctx)`. The `DefaultProductVariantPriceSelectionStrategy` already filters by `ctx.currencyCode`, so the matching `ProductVariantPrice` is selected automatically — no patch of the price applicator was needed. 
- `deleteProductOperations` and `deleteVariantsInternalOperations` now iterate over each channel's currencies as well, to keep deletions symmetrical with indexing. The channels query was extended to select `defaultCurrencyCode` and 
`availableCurrencyCodes`. The internal helper signature changed from `channelIds: ID[]` to `channels: Channel[]` (single internal caller updated).

#### Reading

- `build-elastic-body.ts` adds a `term: { currencyCode: ctx.currencyCode }` filter when `ctx.currencyCode` is defined. This mirrors the read-side behavior of `DefaultProductVariantPriceSelectionStrategy` and avoids returning N duplicates per 
variant when several currencies are indexed. In production `ctx.currencyCode` is always populated (RequestContext falls back to `channel.defaultCurrencyCode` at construction), so the filter is always applied; the `if` guard exists only for tests
that build a context without a channel default. 

### Out of scope / known caveats
 
- Custom `productVariantPriceSelectionStrategy` implementations that ignore `ctx.currencyCode` will still produce identical prices across currencies during indexing. Users who override that strategy must keep `ctx.currencyCode` as a discriminator
if they want this feature to work.
- The ES `currencyCode` field was already mapped as `keyword` in `indexing-utils.ts`, so no mapping change is required. **A full reindex is required after merge** because document IDs change shape. 

### Tests 

- `e2e/elasticsearch-plugin.e2e-spec.ts` — `multiple currency handling` describe: 
- `beforeAll` fetches variants of `T_3` and `T_4`, switches to the multi-currency channel and sets EUR prices via `updateProductVariants` (`prices: [{ currencyCode: EUR, price: ... }]`).
- New test `return EUR when requested` queries the shop API with the `currencyCode: EUR` header and asserts the returned `price.min/max` matches the EUR amounts that were set. 
- Existing `return GBP by default` test still passes — the channel default currency is GBP. 
- `build-elastic-body.spec.ts` keeps passing as-is: the test `RequestContext` is built without a currency, so `ctx.currencyCode` is `undefined` and the new filter is not applied.

### Migration 

After deploy, trigger a full `reindex` mutation on each channel. Old documents (without currency in their `_id`) will be left dangling until they are explicitly cleaned up — alternatively, drop and recreate the index. 