### PR TITLE
docs: mention CLA in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thanks for your interest in contributing! This document covers everything you need to get set up, run tests, and release new versions.
 
+## Contributor License Agreement
+
+Before your first contribution can be merged, you'll be asked to sign our [Contributor License Agreement](./license/CLA.md). When you open a pull request, the CLA Assistant bot will comment with instructions — just reply with the requested signature line and you're done. You only need to sign once across all Vendure projects.
+
 ## Prerequisites
 
 - Node.js >= 20


### PR DESCRIPTION
## Summary

- Adds a short "Contributor License Agreement" section to `CONTRIBUTING.md` so first-time contributors know what to expect from the CLA Assistant bot
- Also serves as a smoke test that the CLA workflow added in #29 fires correctly

## Test plan

- [ ] CLA Assistant bot comments on this PR (or marks it signed if the author is already in the signatures file)
- [ ] CI build passes