### PR TITLE
fix(mollie-payments): wrap addPayment in transaction

### DIFF
--- a/packages/mollie-plugin/src/mollie.service.ts
+++ b/packages/mollie-plugin/src/mollie.service.ts
@@ -377,6 +377,8 @@ export class MollieService {
         paymentMethodCode: string,
         status: 'Authorized' | 'Settled',
     ): Promise<Order> {
+        // `addPaymentToOrder` requires a db transaction. Free orders use a new
+        // admin `RequestContext` in `createPaymentIntent`, which does not keep the transaction.
         return this.connection.withTransaction(_ctx, async ctx => {
             if (order.state !== 'ArrangingPayment' && order.state !== 'ArrangingAdditionalPayment') {
                 const transitionToStateResult = await this.orderService.transitionToState(

--- a/packages/mollie-plugin/src/mollie.service.ts
+++ b/packages/mollie-plugin/src/mollie.service.ts
@@ -370,17 +370,17 @@ export class MollieService {
      * Add payment to order. Can be settled or authorized depending on the payment method.
      */
     async addPayment(
-        ctx: RequestContext,
+        _ctx: RequestContext,
         order: Order,
         amount: number,
         mollieMetadata: Omit<MolliePaymentMetadata, 'status' | 'amount'>,
         paymentMethodCode: string,
         status: 'Authorized' | 'Settled',
     ): Promise<Order> {
-        return this.connection.withTransaction(ctx, async txCtx => {
+        return this.connection.withTransaction(_ctx, async ctx => {
             if (order.state !== 'ArrangingPayment' && order.state !== 'ArrangingAdditionalPayment') {
                 const transitionToStateResult = await this.orderService.transitionToState(
-                    txCtx,
+                    ctx,
                     order.id,
                     'ArrangingPayment',
                 );
@@ -401,7 +401,7 @@ export class MollieService {
                 authorizedAt: mollieMetadata.authorizedAt,
                 paidAt: mollieMetadata.paidAt,
             };
-            const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(txCtx, order.id, {
+            const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(ctx, order.id, {
                 method: paymentMethodCode,
                 metadata,
             });

--- a/packages/mollie-plugin/src/mollie.service.ts
+++ b/packages/mollie-plugin/src/mollie.service.ts
@@ -29,6 +29,7 @@ import {
     PaymentMethod,
     PaymentMethodService,
     RequestContext,
+    TransactionalConnection,
 } from '@vendure/core';
 import { totalCoveredByPayments } from '@vendure/core/dist/service/helpers/utils/order-utils';
 
@@ -82,6 +83,7 @@ export class MollieService {
         @Inject(PLUGIN_INIT_OPTIONS) private options: MolliePluginOptions,
         private activeOrderService: ActiveOrderService,
         private orderService: OrderService,
+        private connection: TransactionalConnection,
         private entityHydrator: EntityHydrator,
         private moduleRef: ModuleRef,
         private configService: ConfigService,
@@ -375,37 +377,39 @@ export class MollieService {
         paymentMethodCode: string,
         status: 'Authorized' | 'Settled',
     ): Promise<Order> {
-        if (order.state !== 'ArrangingPayment' && order.state !== 'ArrangingAdditionalPayment') {
-            const transitionToStateResult = await this.orderService.transitionToState(
-                ctx,
-                order.id,
-                'ArrangingPayment',
-            );
-            if (transitionToStateResult instanceof OrderStateTransitionError) {
-                throw Error(
-                    `Error transitioning order ${order.code} from ${transitionToStateResult.fromState} ` +
-                        `to ${transitionToStateResult.toState}: ${transitionToStateResult.message}`,
+        return this.connection.withTransaction(ctx, async txCtx => {
+            if (order.state !== 'ArrangingPayment' && order.state !== 'ArrangingAdditionalPayment') {
+                const transitionToStateResult = await this.orderService.transitionToState(
+                    txCtx,
+                    order.id,
+                    'ArrangingPayment',
                 );
+                if (transitionToStateResult instanceof OrderStateTransitionError) {
+                    throw Error(
+                        `Error transitioning order ${order.code} from ${transitionToStateResult.fromState} ` +
+                            `to ${transitionToStateResult.toState}: ${transitionToStateResult.message}`,
+                    );
+                }
             }
-        }
-        const metadata: MolliePaymentMetadata = {
-            amount,
-            status,
-            paymentId: mollieMetadata.paymentId,
-            mode: mollieMetadata.mode,
-            method: mollieMetadata.method,
-            profileId: mollieMetadata.profileId,
-            authorizedAt: mollieMetadata.authorizedAt,
-            paidAt: mollieMetadata.paidAt,
-        };
-        const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(ctx, order.id, {
-            method: paymentMethodCode,
-            metadata,
+            const metadata: MolliePaymentMetadata = {
+                amount,
+                status,
+                paymentId: mollieMetadata.paymentId,
+                mode: mollieMetadata.mode,
+                method: mollieMetadata.method,
+                profileId: mollieMetadata.profileId,
+                authorizedAt: mollieMetadata.authorizedAt,
+                paidAt: mollieMetadata.paidAt,
+            };
+            const addPaymentToOrderResult = await this.orderService.addPaymentToOrder(txCtx, order.id, {
+                method: paymentMethodCode,
+                metadata,
+            });
+            if (!(addPaymentToOrderResult instanceof Order)) {
+                throw Error(`Error adding payment to order ${order.code}: ${addPaymentToOrderResult.message}`);
+            }
+            return addPaymentToOrderResult;
         });
-        if (!(addPaymentToOrderResult instanceof Order)) {
-            throw Error(`Error adding payment to order ${order.code}: ${addPaymentToOrderResult.message}`);
-        }
-        return addPaymentToOrderResult;
     }
 
     /**


### PR DESCRIPTION
This PR includes:

With the recent release of Vendure, it requires the `transitionOrderToState` and `addPaymentToOrder` fns to be wrapped in a Transaction. 
That wasn't handled inside the `addPayment` helper function in the Mollie service.

cc @martijnvdbrug would be nice to have your input on this too, please 🙏

Related Vendure Core PR: https://github.com/vendurehq/vendure/pull/4689

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/community-plugins/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->