### PR TITLE
fix(elasticsearch-plugin): Filter stock level on enabled variants only

### DIFF
--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -45,12 +45,14 @@ import {
 } from './e2e-helpers';
 import { graphql, ResultOf } from './graphql/graphql-admin';
 import {
+    addOptionGroupToProductDocument,
     assignProductToChannelDocument,
     assignProductVariantToChannelDocument,
     createChannelDocument,
     createCollectionDocument,
     createFacetDocument,
     createProductDocument,
+    createProductOptionGroupDocument,
     createProductVariantsDocument,
     deleteAssetDocument,
     deleteProductDocument,
@@ -1576,6 +1578,119 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
 
         afterAll(() => {
             shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        });
+    });
+
+    // https://github.com/vendurehq/community-plugins/pull/35
+    describe('productInStock ignores disabled variants', () => {
+        const PRODUCT_NAME = 'Disabled Variant Stock Test Product';
+        let testProductId: string;
+        let variantWithStockId: string;
+
+        beforeAll(async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await adminClient.asSuperAdmin();
+
+            const { createProduct } = await adminClient.query(createProductDocument, {
+                input: {
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: PRODUCT_NAME,
+                            slug: 'disabled-variant-stock-test-product',
+                            description: 'A product for testing that disabled variants do not affect productInStock',
+                        },
+                    ],
+                },
+            });
+            testProductId = createProduct.id;
+
+            const { createProductOptionGroup } = await adminClient.query(
+                createProductOptionGroupDocument,
+                {
+                    input: {
+                        code: 'disabled-variant-stock-size',
+                        translations: [{ languageCode: LanguageCode.en, name: 'Size' }],
+                        options: [
+                            {
+                                code: 'dvs-small',
+                                translations: [{ languageCode: LanguageCode.en, name: 'Small' }],
+                            },
+                            {
+                                code: 'dvs-large',
+                                translations: [{ languageCode: LanguageCode.en, name: 'Large' }],
+                            },
+                        ],
+                    },
+                },
+            );
+            await adminClient.query(addOptionGroupToProductDocument, {
+                productId: testProductId,
+                optionGroupId: createProductOptionGroup.id,
+            });
+            const smallOptionId = createProductOptionGroup.options.find(o => o.code === 'dvs-small')!.id;
+            const largeOptionId = createProductOptionGroup.options.find(o => o.code === 'dvs-large')!.id;
+
+            const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                input: [
+                    {
+                        productId: testProductId,
+                        sku: 'DIS-VAR-OOS',
+                        price: 1000,
+                        stockOnHand: 0,
+                        trackInventory: GlobalFlag.TRUE,
+                        optionIds: [smallOptionId],
+                        translations: [{ languageCode: LanguageCode.en, name: 'Out of stock variant' }],
+                    },
+                    {
+                        productId: testProductId,
+                        sku: 'DIS-VAR-INSTOCK',
+                        price: 1000,
+                        stockOnHand: 100,
+                        trackInventory: GlobalFlag.TRUE,
+                        optionIds: [largeOptionId],
+                        translations: [{ languageCode: LanguageCode.en, name: 'In stock variant' }],
+                    },
+                ],
+            });
+            variantWithStockId = createProductVariants.find(v => v?.sku === 'DIS-VAR-INSTOCK')!.id;
+            await awaitRunningJobs(adminClient);
+        });
+
+        it('product is inStock while both variants are enabled', async () => {
+            const result = await shopClient.query(searchProductsShopDocument, {
+                input: {
+                    term: PRODUCT_NAME,
+                    groupByProduct: true,
+                    inStock: true,
+                },
+            });
+            expect(result.search.items.map(i => i.productName)).toContain(PRODUCT_NAME);
+        });
+
+        it('product is NOT inStock once the in-stock variant is disabled', async () => {
+            await adminClient.query(updateProductVariantsDocument, {
+                input: [{ id: variantWithStockId, enabled: false }],
+            });
+            await awaitRunningJobs(adminClient);
+
+            const inStockResult = await shopClient.query(searchProductsShopDocument, {
+                input: {
+                    term: PRODUCT_NAME,
+                    groupByProduct: true,
+                    inStock: true,
+                },
+            });
+            expect(inStockResult.search.items.map(i => i.productName)).not.toContain(PRODUCT_NAME);
+
+            const notInStockResult = await shopClient.query(searchProductsShopDocument, {
+                input: {
+                    term: PRODUCT_NAME,
+                    groupByProduct: true,
+                    inStock: false,
+                },
+            });
+            expect(notInStockResult.search.items.map(i => i.productName)).toContain(PRODUCT_NAME);
         });
     });
 });

--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin.e2e-spec.ts
@@ -1581,7 +1581,6 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
         });
     });
 
-    // https://github.com/vendurehq/community-plugins/pull/35
     describe('productInStock ignores disabled variants', () => {
         const PRODUCT_NAME = 'Disabled Variant Stock Test Product';
         let testProductId: string;
@@ -1668,29 +1667,35 @@ describe(`Elasticsearch plugin [${searchBackend as string}]`, () => {
             expect(result.search.items.map(i => i.productName)).toContain(PRODUCT_NAME);
         });
 
-        it('product is NOT inStock once the in-stock variant is disabled', async () => {
-            await adminClient.query(updateProductVariantsDocument, {
-                input: [{ id: variantWithStockId, enabled: false }],
+        describe('after disabling the in-stock variant', () => {
+            beforeAll(async () => {
+                await adminClient.query(updateProductVariantsDocument, {
+                    input: [{ id: variantWithStockId, enabled: false }],
+                });
+                await awaitRunningJobs(adminClient);
             });
-            await awaitRunningJobs(adminClient);
 
-            const inStockResult = await shopClient.query(searchProductsShopDocument, {
-                input: {
-                    term: PRODUCT_NAME,
-                    groupByProduct: true,
-                    inStock: true,
-                },
+            it('product does not appear in inStock: true results', async () => {
+                const result = await shopClient.query(searchProductsShopDocument, {
+                    input: {
+                        term: PRODUCT_NAME,
+                        groupByProduct: true,
+                        inStock: true,
+                    },
+                });
+                expect(result.search.items.map(i => i.productName)).not.toContain(PRODUCT_NAME);
             });
-            expect(inStockResult.search.items.map(i => i.productName)).not.toContain(PRODUCT_NAME);
 
-            const notInStockResult = await shopClient.query(searchProductsShopDocument, {
-                input: {
-                    term: PRODUCT_NAME,
-                    groupByProduct: true,
-                    inStock: false,
-                },
+            it('product appears in inStock: false results', async () => {
+                const result = await shopClient.query(searchProductsShopDocument, {
+                    input: {
+                        term: PRODUCT_NAME,
+                        groupByProduct: true,
+                        inStock: false,
+                    },
+                });
+                expect(result.search.items.map(i => i.productName)).toContain(PRODUCT_NAME);
             });
-            expect(notInStockResult.search.items.map(i => i.productName)).toContain(PRODUCT_NAME);
         });
     });
 });

--- a/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
+++ b/packages/elasticsearch-plugin/src/indexing/indexer.controller.ts
@@ -976,8 +976,9 @@ export class ElasticsearchIndexerController implements OnModuleInit, OnModuleDes
             ctx,
             `elastic-index-product-in-stock-${ctx.channelId}-${variants.map(v => v.id).join(',')}`,
             async () => {
+                const enabledVariants = variants.filter(variant => variant.enabled);
                 const stockLevels = await Promise.all(
-                    variants.map(variant => this.productVariantService.getSaleableStockLevel(ctx, variant)),
+                    enabledVariants.map(variant => this.productVariantService.getSaleableStockLevel(ctx, variant)),
                 );
                 return stockLevels.some(stockLevel => 0 < stockLevel);
             },


### PR DESCRIPTION
# Context

1. Ensure a product with at least 2 variants
2. Variant 1 is out of stock and variant 2 has stock available
3. Disable variant 2
4. Elasticsearch result shows the product has stock available by counting the disabled variant.

This particular change seems to fix the issue based on my testing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/community-plugins/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782984723&installation_id=128408429&pr_number=35&repository=vendurehq%2Fcommunity-plugins&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fcommunity-plugins%2Fpull%2F35&signature=4d7b411b004557dbe86c09536773ecad1e0a45bb56b116a2ff0bd407c9012efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->