### PR TITLE
feat(stripe-plugin)!: modernize for Stripe SDK 22 / dahlia API (OSS-555 items 1-3, 6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -199,8 +199,8 @@
         "@vendure/common": "3.6.0-minor-202603280303",
         "@vendure/core": "3.6.0-minor-202603280303",
         "@vendure/testing": "3.6.0-minor-202603280303",
-        "nock": "^13.1.4",
-        "rimraf": "^5.0.5",
+        "nock": "^14.0.0",
+        "rimraf": "^6.0.0",
         "stripe": "^22.0.0",
         "typescript": "5.8.2",
       },
@@ -528,6 +528,8 @@
 
     "@mollie/api-client": ["@mollie/api-client@4.5.0", "", { "dependencies": { "@types/node-fetch": "^2.6.13", "node-fetch": "^2.7.0", "ruply": "^1.0.1" } }, "sha512-Aj3Erv3EqY74fFK8gYegjzXZxPNq4T7cbsoPueRx5aF6o0kL8kR9eeaLZPaFkv2zHA4XQW6ky8yG7CMyu4oqnw=="],
 
+    "@mswjs/interceptors": ["@mswjs/interceptors@0.41.9", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.4", "", { "dependencies": { "@emnapi/core": "^1.1.0", "@emnapi/runtime": "^1.1.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ=="],
 
     "@nestjs/apollo": ["@nestjs/apollo@13.1.0", "", { "dependencies": { "@apollo/server-plugin-landing-page-graphql-playground": "4.0.1", "iterall": "1.3.0", "lodash.omit": "4.5.0", "tslib": "2.8.1" }, "peerDependencies": { "@apollo/gateway": "^2.0.0", "@apollo/server": "^4.11.3", "@apollo/subgraph": "^2.0.0", "@as-integrations/fastify": "^2.1.1", "@nestjs/common": "^11.0.1", "@nestjs/core": "^11.0.1", "@nestjs/graphql": "^13.0.0", "graphql": "^16.10.0" }, "optionalPeers": ["@apollo/gateway", "@apollo/subgraph", "@as-integrations/fastify"] }, "sha512-/FRg195AxpZ58Kjd7geeksaRs3blmlGMDUak7WGbrl7ZWX7J9VuulhTjVHP6Z+dhH4Tn+AsyjkkJ2euC8psv3A=="],
@@ -631,6 +633,12 @@
     "@octokit/rest": ["@octokit/rest@20.1.2", "", { "dependencies": { "@octokit/core": "^5.0.2", "@octokit/plugin-paginate-rest": "11.4.4-cjs.2", "@octokit/plugin-request-log": "^4.0.0", "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1" } }, "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA=="],
 
     "@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
+
+    "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
     "@opensearch-project/opensearch": ["@opensearch-project/opensearch@3.5.1", "", { "dependencies": { "aws4": "^1.11.0", "debug": "^4.3.1", "hpagent": "^1.2.0", "json11": "^2.0.0", "ms": "^2.1.3", "secure-json-parse": "^2.4.0" } }, "sha512-6bf+HcuERzAtHZxrm6phjref54ABse39BpkDie/YO3AUFMCBrb3SK5okKSdT5n3+nDRuEEQLhQCl0RQV3s1qpA=="],
 
@@ -1770,6 +1778,8 @@
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
+    "is-node-process": ["is-node-process@1.2.0", "", {}, "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
@@ -2178,6 +2188,8 @@
 
     "ora": ["ora@5.3.0", "", { "dependencies": { "bl": "^4.0.3", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "log-symbols": "^4.0.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g=="],
 
+    "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
+
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
     "p-defer": ["p-defer@3.0.0", "", {}, "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="],
@@ -2511,6 +2523,8 @@
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
     "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
+    "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -2950,6 +2964,10 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@vendure-community/stripe-plugin/nock": ["nock@14.0.15", "", { "dependencies": { "@mswjs/interceptors": "^0.41.0", "json-stringify-safe": "^5.0.1", "propagate": "^2.0.0" } }, "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg=="],
+
+    "@vendure-community/stripe-plugin/rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
+
     "@vendure/core/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
@@ -3246,6 +3264,8 @@
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
+    "@vendure-community/stripe-plugin/rimraf/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
     "apache-arrow/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "bin-links/write-file-atomic/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
@@ -3364,6 +3384,10 @@
 
     "@sigstore/sign/make-fetch-happen/minipass-fetch/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
 
+    "@vendure-community/stripe-plugin/rimraf/glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "@vendure-community/stripe-plugin/rimraf/glob/path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
     "cacache/glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "get-pkg-repo/hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
@@ -3393,6 +3417,8 @@
     "tuf-js/make-fetch-happen/minipass-fetch/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "tuf-js/make-fetch-happen/minipass-fetch/minipass-sized": ["minipass-sized@2.0.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA=="],
+
+    "@vendure-community/stripe-plugin/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "meow/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/elasticsearch-plugin": {
       "name": "@vendure-community/elasticsearch-plugin",
-      "version": "2.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "fast-deep-equal": "^3.1.3",
@@ -100,7 +100,7 @@
     },
     "packages/mollie-plugin": {
       "name": "@vendure-community/mollie-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "currency.js": "2.0.4",
       },
@@ -201,13 +201,13 @@
         "@vendure/testing": "3.6.0-minor-202603280303",
         "nock": "^13.1.4",
         "rimraf": "^5.0.5",
-        "stripe": "^13.3.0",
+        "stripe": "^22.0.0",
         "typescript": "5.8.2",
       },
       "peerDependencies": {
         "@vendure/common": "^3.6.0-0",
         "@vendure/core": "^3.6.0-0",
-        "stripe": "13.x",
+        "stripe": "^22.0.0",
       },
     },
   },
@@ -2542,7 +2542,7 @@
 
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
-    "stripe": ["stripe@13.11.0", "", { "dependencies": { "@types/node": ">=8.1.0", "qs": "^6.11.0" } }, "sha512-yPxVJxUzP1QHhHeFnYjJl48QwDS1+5befcL7ju7+t+i88D5r0rbsL+GkCCS6zgcU+TiV5bF9eMGcKyJfLf8BZQ=="],
+    "stripe": ["stripe@22.2.0", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-WFGpMOom9QZqso1kcnSwJsCdC1QHDlMoCOxBZRf3JraMzhkfw7dgSdD2a1CFZrqC+mzAfqeEtYILrZhWKIDruA=="],
 
     "strtok3": ["strtok3@9.1.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^5.3.1" } }, "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw=="],
 

--- a/packages/stripe-plugin/CHANGELOG.md
+++ b/packages/stripe-plugin/CHANGELOG.md
@@ -12,21 +12,27 @@ Major modernization release. Brings the plugin onto the current Stripe SDK and a
 
 - **`stripe` peer dependency: `13.x` → `^22.0.0`.** Bump `stripe` in your project to a matching
   version when upgrading. The wire-format and TypeScript types have been updated to match.
-- **Default Stripe API version is now pinned to the SDK's latest (`2026-05-27.dahlia`)** instead of
-  sending no version header (which previously fell back to the Stripe account default). This keeps
-  responses aligned with the SDK's typings. If your integration relied on the account default —
-  e.g. because you've held off upgrading API versions in the Stripe dashboard — set the new
-  `apiVersion` plugin option to `null` to restore the old behaviour:
+- **Default Stripe API version is now pinned to the SDK's latest (`2026-05-27.dahlia`).** Pre-2.0.0,
+  the plugin passed `apiVersion: null` and assumed the Stripe SDK would omit the `Stripe-Version`
+  header so the request would fall back to the Stripe account's default API version. In practice
+  the SDK has always coerced `null` to its own pinned default (see `props.apiVersion || DEFAULT_API_VERSION`
+  in `stripe.core.js`) — both on v13 and v22 — so the previous behaviour was already the SDK pinned
+  version (just an older one). With this release the responses will now come back shaped according
+  to dahlia rather than 2023-08-16.
+
+  If your code expects the older response shape, pin to the older version via the new `apiVersion`
+  option:
 
   ```ts
+  import type { StripeLatestApiVersion } from '@vendure-community/stripe-plugin';
+
   StripePlugin.init({
       // ...
-      apiVersion: null,
+      apiVersion: '2023-08-16' as StripeLatestApiVersion,
   });
   ```
 
-  To pin to a specific version other than the SDK default, pass it as a string (cast to
-  `StripeLatestApiVersion`).
+  There is no way on stripe-node v22 to instruct the SDK to omit the version header entirely.
 - **HTTP transport switched from `node:http`/`node:https` to the platform `fetch`.** The plugin
   configures Stripe's `FetchHttpClient` so the SDK uses `globalThis.fetch` (Node 18+, which is the
   minimum the SDK supports). Behaviour is functionally identical for normal use; if you relied on a

--- a/packages/stripe-plugin/CHANGELOG.md
+++ b/packages/stripe-plugin/CHANGELOG.md
@@ -29,9 +29,21 @@ Major modernization release. Brings the plugin onto the current Stripe SDK and a
   `StripeLatestApiVersion`).
 - **HTTP transport switched from `node:http`/`node:https` to the platform `fetch`.** The plugin
   configures Stripe's `FetchHttpClient` so the SDK uses `globalThis.fetch` (Node 18+, which is the
-  minimum the SDK supports). Behaviour is functionally identical for normal use; if you relied on
-  custom `http.Agent` settings (proxies, keep-alive tuning) injected into the previous transport,
-  reach out — we'll add an explicit hook.
+  minimum the SDK supports). Behaviour is functionally identical for normal use; if you relied on a
+  custom `http.Agent` (proxies, keep-alive tuning), pass your own `Stripe.createNodeHttpClient(...)`
+  via the new `httpClient` plugin option:
+
+  ```ts
+  import Stripe from 'stripe';
+  import { HttpsProxyAgent } from 'https-proxy-agent';
+
+  StripePlugin.init({
+      // ...
+      httpClient: Stripe.createNodeHttpClient(
+          new HttpsProxyAgent(process.env.HTTPS_PROXY!),
+      ),
+  });
+  ```
 
 ### Improvements
 

--- a/packages/stripe-plugin/CHANGELOG.md
+++ b/packages/stripe-plugin/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2.0.0
+
+Major modernization release. Brings the plugin onto the current Stripe SDK and aligns it with the
+2026 (`dahlia`) API version.
+
+### Breaking changes
+
+- **`stripe` peer dependency: `13.x` → `^22.0.0`.** Bump `stripe` in your project to a matching
+  version when upgrading. The wire-format and TypeScript types have been updated to match.
+- **Default Stripe API version is now pinned to the SDK's latest (`2026-05-27.dahlia`)** instead of
+  sending no version header (which previously fell back to the Stripe account default). This keeps
+  responses aligned with the SDK's typings. If your integration relied on the account default —
+  e.g. because you've held off upgrading API versions in the Stripe dashboard — set the new
+  `apiVersion` plugin option to `null` to restore the old behaviour:
+
+  ```ts
+  StripePlugin.init({
+      // ...
+      apiVersion: null,
+  });
+  ```
+
+  To pin to a specific version other than the SDK default, pass it as a string (cast to
+  `StripeLatestApiVersion`).
+- **HTTP transport switched from `node:http`/`node:https` to the platform `fetch`.** The plugin
+  configures Stripe's `FetchHttpClient` so the SDK uses `globalThis.fetch` (Node 18+, which is the
+  minimum the SDK supports). Behaviour is functionally identical for normal use; if you relied on
+  custom `http.Agent` settings (proxies, keep-alive tuning) injected into the previous transport,
+  reach out — we'll add an explicit hook.
+
+### Improvements
+
+- **Refund `reason` is forwarded.** When the Vendure refund input includes a `reason` matching
+  one of Stripe's accepted enum values (`duplicate`, `fraudulent`, `requested_by_customer`), it is
+  passed as the structured `reason` field. Any other reason string is stored on the Stripe refund's
+  metadata as `vendureRefundReason` so it isn't lost.
+- **Refund creation is now idempotent.** `refunds.create` is called with an idempotency key derived
+  from the payment intent ID and refund amount, matching the parity already in place for payment
+  intent creation.
+
+### Development
+
+- `nock` 13 → 14, `rimraf` 5 → 6.
+
 ## 1.0.0 (2026-03-30)
 
 Initial release as `@vendure-community/stripe-plugin`, extracted from `@vendure/payments-plugin`.

--- a/packages/stripe-plugin/README.md
+++ b/packages/stripe-plugin/README.md
@@ -16,6 +16,9 @@ the Stripe CLI to test your webhook locally. See the _local development_ section
     npm install @vendure-community/stripe-plugin stripe
     ```
 
+    `@vendure-community/stripe-plugin@2.x` requires `stripe@^22`. If you're upgrading from `1.x`,
+    bump both packages together and see the [CHANGELOG](./CHANGELOG.md) for migration notes.
+
 ## Setup
 
 1. Add the plugin to your VendureConfig `plugins` array:

--- a/packages/stripe-plugin/e2e/graphql/graphql-admin.ts
+++ b/packages/stripe-plugin/e2e/graphql/graphql-admin.ts
@@ -1,5 +1,5 @@
-import { initGraphQLTada } from 'gql.tada';
 import type { introspection } from './graphql-env-admin.d.ts';
+import { initGraphQLTada } from 'gql.tada';
 
 export const graphql = initGraphQLTada<{
     disableMasking: true;

--- a/packages/stripe-plugin/e2e/graphql/graphql-shop.ts
+++ b/packages/stripe-plugin/e2e/graphql/graphql-shop.ts
@@ -1,5 +1,5 @@
-import { initGraphQLTada } from 'gql.tada';
 import type { introspection } from './graphql-env-shop.d.ts';
+import { initGraphQLTada } from 'gql.tada';
 
 export const graphql = initGraphQLTada<{
     disableMasking: true;

--- a/packages/stripe-plugin/e2e/stripe-dev-server.ts
+++ b/packages/stripe-plugin/e2e/stripe-dev-server.ts
@@ -1,4 +1,3 @@
-import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
 import {
     ChannelService,
     DefaultLogger,
@@ -9,6 +8,7 @@ import {
     OrderService,
     RequestContext,
 } from '@vendure/core';
+import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
 import { createTestEnvironment, registerInitializer, SqljsInitializer } from '@vendure/testing';
 import path from 'path';
 
@@ -42,7 +42,7 @@ const createCustomStripePaymentIntentDocument = shopGraphql(`
  *      paste the resulting signing secret as STRIPE_WEBHOOK_SECRET.
  *   3. `npm run dev-server` — then open http://localhost:3050/checkout.
  */
-(async () => {
+void (async () => {
     require('dotenv').config();
     const testConfigInstance = testConfig();
     registerInitializer('sqljs', new SqljsInitializer(path.join(__dirname, '__data__')));
@@ -82,8 +82,8 @@ const createCustomStripePaymentIntentDocument = shopGraphql(`
             handler: {
                 code: stripePaymentMethodHandler.code,
                 arguments: [
-                    { name: 'apiKey', value: process.env.STRIPE_APIKEY! },
-                    { name: 'webhookSecret', value: process.env.STRIPE_WEBHOOK_SECRET! },
+                    { name: 'apiKey', value: process.env.STRIPE_APIKEY ?? '' },
+                    { name: 'webhookSecret', value: process.env.STRIPE_WEBHOOK_SECRET ?? '' },
                 ],
             },
         },

--- a/packages/stripe-plugin/e2e/stripe-dev-server.ts
+++ b/packages/stripe-plugin/e2e/stripe-dev-server.ts
@@ -1,4 +1,4 @@
-import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
+import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
 import {
     ChannelService,
     DefaultLogger,
@@ -9,85 +9,87 @@ import {
     OrderService,
     RequestContext,
 } from '@vendure/core';
-import { createTestEnvironment, registerInitializer, SqljsInitializer, testConfig } from '@vendure/testing';
+import { createTestEnvironment, registerInitializer, SqljsInitializer } from '@vendure/testing';
 import path from 'path';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { testConfig } from '../../../e2e-common/test-config';
 import { StripePlugin } from '../src';
 import { stripePaymentMethodHandler } from '../src/stripe.handler';
 
-/* eslint-disable */
 import { StripeCheckoutTestPlugin } from './fixtures/stripe-checkout-test.plugin';
 import { StripeServiceExportTestPlugin } from './fixtures/stripe-service-export-test.plugin';
-import { CREATE_PAYMENT_METHOD } from './graphql/admin-queries';
-import {
-    CreatePaymentMethodMutation,
-    CreatePaymentMethodMutationVariables,
-} from './graphql/generated-admin-types';
-import { AddItemToOrderMutation, AddItemToOrderMutationVariables } from './graphql/generated-shop-types';
-import { ADD_ITEM_TO_ORDER } from './graphql/shop-queries';
-import {
-    CREATE_CUSTOM_STRIPE_PAYMENT_INTENT,
-    CREATE_STRIPE_PAYMENT_INTENT,
-    setShipping,
-} from './payment-helpers';
+import { createPaymentMethodDocument } from './graphql/admin-definitions';
+import { graphql as shopGraphql } from './graphql/graphql-shop';
+import { createStripePaymentIntentDocument } from './graphql/shared-definitions';
+import { addItemToOrderDocument } from './graphql/shop-definitions';
+import { setShipping } from './payment-helpers';
 
 export let clientSecret: string;
 
+const createCustomStripePaymentIntentDocument = shopGraphql(`
+    mutation CreateCustomStripePaymentIntent($orderCode: String!, $channelToken: String!) {
+        createCustomStripePaymentIntent(orderCode: $orderCode, channelToken: $channelToken)
+    }
+`);
+
 /**
- * The actual starting of the dev server
+ * Locally test the Stripe payment plugin against a real Stripe test account.
+ *
+ *   1. Put STRIPE_APIKEY, STRIPE_WEBHOOK_SECRET, STRIPE_PUBLISHABLE_KEY in a
+ *      `.env` next to this file (or in your shell).
+ *   2. Run `stripe listen --forward-to localhost:3050/payments/stripe` and
+ *      paste the resulting signing secret as STRIPE_WEBHOOK_SECRET.
+ *   3. `npm run dev-server` — then open http://localhost:3050/checkout.
  */
 (async () => {
     require('dotenv').config();
-
+    const testConfigInstance = testConfig();
     registerInitializer('sqljs', new SqljsInitializer(path.join(__dirname, '__data__')));
-    const config = mergeConfig(testConfig, {
+    const config = mergeConfig(testConfigInstance, {
         plugins: [
-            ...testConfig.plugins,
-            AdminUiPlugin.init({
-                route: 'admin',
-                port: 5001,
-            }),
+            ...testConfigInstance.plugins,
+            GraphiqlPlugin.init({ route: 'graphiql' }),
             StripePlugin.init({}),
             StripeCheckoutTestPlugin,
             StripeServiceExportTestPlugin,
         ],
         logger: new DefaultLogger({ level: LogLevel.Debug }),
+        apiOptions: {
+            ...testConfigInstance.apiOptions,
+            adminApiPlayground: true,
+            shopApiPlayground: true,
+        },
     });
-    const { server, shopClient, adminClient } = createTestEnvironment(config as any);
+    const { server, shopClient, adminClient } = createTestEnvironment(config);
     await server.init({
         initialData,
         productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
         customerCount: 1,
     });
-    // Create method
     await adminClient.asSuperAdmin();
-    await adminClient.query<CreatePaymentMethodMutation, CreatePaymentMethodMutationVariables>(
-        CREATE_PAYMENT_METHOD,
-        {
-            input: {
-                code: 'stripe-payment-method',
-                enabled: true,
-                translations: [
-                    {
-                        name: 'Stripe',
-                        description: 'This is a Stripe test payment method',
-                        languageCode: LanguageCode.en,
-                    },
-                ],
-                handler: {
-                    code: stripePaymentMethodHandler.code,
-                    arguments: [
-                        { name: 'apiKey', value: process.env.STRIPE_APIKEY! },
-                        { name: 'webhookSecret', value: process.env.STRIPE_WEBHOOK_SECRET! },
-                    ],
+    await adminClient.query(createPaymentMethodDocument, {
+        input: {
+            code: 'stripe-payment-method',
+            enabled: true,
+            translations: [
+                {
+                    name: 'Stripe',
+                    description: 'This is a Stripe test payment method',
+                    languageCode: LanguageCode.en,
                 },
+            ],
+            handler: {
+                code: stripePaymentMethodHandler.code,
+                arguments: [
+                    { name: 'apiKey', value: process.env.STRIPE_APIKEY! },
+                    { name: 'webhookSecret', value: process.env.STRIPE_WEBHOOK_SECRET! },
+                ],
             },
         },
-    );
-    // Prepare order for payment
+    });
     await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
-    await shopClient.query<AddItemToOrderMutation, AddItemToOrderMutationVariables>(ADD_ITEM_TO_ORDER, {
+    await shopClient.query(addItemToOrderDocument, {
         productVariantId: 'T_1',
         quantity: 1,
     });
@@ -102,12 +104,9 @@ export let clientSecret: string;
         listPrice: -20000,
     });
     await setShipping(shopClient);
-    const { createStripePaymentIntent } = await shopClient.query(CREATE_STRIPE_PAYMENT_INTENT);
-    clientSecret = createStripePaymentIntent;
-
-    // Showcasing the custom intent creation
-    const { createCustomStripePaymentIntent } = await shopClient.query(CREATE_CUSTOM_STRIPE_PAYMENT_INTENT);
-    Logger.debug('Result of createCustomStripePaymentIntent:', createCustomStripePaymentIntent);
+    const { createStripePaymentIntent } = await shopClient.query(createStripePaymentIntentDocument);
+    clientSecret = createStripePaymentIntent as string;
 
     Logger.info('http://localhost:3050/checkout', 'Stripe DevServer');
+    Logger.info('http://localhost:3050/graphiql', 'Stripe DevServer');
 })();

--- a/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -15,7 +15,7 @@ import {
 import nock from 'nock';
 import fetch from 'node-fetch';
 import path from 'path';
-import { Stripe } from 'stripe';
+import Stripe from 'stripe';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
@@ -397,7 +397,7 @@ describe('Stripe payments', () => {
         };
 
         const payloadString = JSON.stringify(MOCKED_WEBHOOK_PAYLOAD, null, 2);
-        const stripeWebhooks = new Stripe('test-api-secret', { apiVersion: '2023-08-16' }).webhooks;
+        const stripeWebhooks = new Stripe('test-api-secret').webhooks;
         const header = stripeWebhooks.generateTestHeaderString({
             payload: payloadString,
             secret: 'test-signing-secret',
@@ -452,7 +452,7 @@ describe('Stripe payments', () => {
         };
 
         const payloadString = JSON.stringify(MOCKED_WEBHOOK_PAYLOAD, null, 2);
-        const stripeWebhooks = new Stripe('test-api-secret', { apiVersion: '2023-08-16' }).webhooks;
+        const stripeWebhooks = new Stripe('test-api-secret').webhooks;
         const header = stripeWebhooks.generateTestHeaderString({
             payload: payloadString,
             secret: 'test-signing-secret',

--- a/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -9,11 +9,6 @@ import {
     RequestContext,
 } from '@vendure/core';
 import {
-    createProductDocument,
-    createProductVariantsDocument,
-    testCreateStockLocationDocument,
-} from './graphql/admin-definitions';
-import {
     createErrorResultGuard,
     createTestEnvironment,
     E2E_DEFAULT_CHANNEL_TOKEN,
@@ -32,6 +27,11 @@ import { VendureStripeClient } from '../src/stripe-client';
 import { stripePaymentMethodHandler } from '../src/stripe.handler';
 import { StripeService } from '../src/stripe.service';
 
+import {
+    createProductDocument,
+    createProductVariantsDocument,
+    testCreateStockLocationDocument,
+} from './graphql/admin-definitions';
 import {
     createChannelDocument,
     createPaymentMethodDocument,
@@ -629,7 +629,7 @@ describe('Stripe payments', () => {
                 languageCode: LanguageCode.en,
             });
             const orders = await orderService.findAll(ctx, { take: 1 });
-            const realOrder = orders.items[0]!;
+            const realOrder = orders.items[0];
             const syntheticPayment = { transactionId: paymentIntentId } as Payment;
             return stripeService.createRefund(ctx, realOrder, syntheticPayment, refundAmount, reason);
         }

--- a/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { CurrencyCode, LanguageCode } from '@vendure/common/lib/generated-types';
-import { EntityHydrator, mergeConfig } from '@vendure/core';
+import {
+    ChannelService,
+    EntityHydrator,
+    mergeConfig,
+    OrderService,
+    Payment,
+    RequestContext,
+} from '@vendure/core';
 import {
     createProductDocument,
     createProductVariantsDocument,
@@ -21,7 +28,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { initialData } from '../../../e2e-common/e2e-initial-data';
 import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 import { StripePlugin } from '../src';
+import { VendureStripeClient } from '../src/stripe-client';
 import { stripePaymentMethodHandler } from '../src/stripe.handler';
+import { StripeService } from '../src/stripe.service';
 
 import {
     createChannelDocument,
@@ -569,6 +578,120 @@ describe('Stripe payments', () => {
             const { createStripePaymentIntent } = await shopClient.query(createStripePaymentIntentDocument);
             expect(createPaymentIntentPayload.amount).toBe((activeOrder!.totalWithTax / 100).toString());
             expect(createPaymentIntentPayload.currency).toBe('jpy');
+        });
+    });
+
+    // Pre-merge confidence tests for OSS-555 items 2 & 6.
+    describe('VendureStripeClient configuration', () => {
+        it('sets Stripe-Version header to the SDK pinned version by default', async () => {
+            let capturedVersion: string | string[] | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/customers')
+                .reply(function reply() {
+                    capturedVersion = this.req.headers['stripe-version'];
+                    return [200, { id: 'cus_test' }];
+                });
+            const client = new VendureStripeClient('sk_test_key', 'whsec_test');
+            await client.customers.create({ email: 'test@example.com' });
+            // The exact pinned version is owned by the SDK release; just assert
+            // we got a real header that smells like a dahlia / clover / basil API date.
+            expect(capturedVersion).toMatch(/^\d{4}-\d{2}-\d{2}(\.\w+)?$/);
+        });
+
+        it('sets Stripe-Version header to the explicit override when provided', async () => {
+            let capturedVersion: string | string[] | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/customers')
+                .reply(function reply() {
+                    capturedVersion = this.req.headers['stripe-version'];
+                    return [200, { id: 'cus_test' }];
+                });
+            const client = new VendureStripeClient('sk_test_key', 'whsec_test', '2024-06-20' as any);
+            await client.customers.create({ email: 'test@example.com' });
+            expect(capturedVersion).toBe('2024-06-20');
+        });
+    });
+
+    describe('createRefund', () => {
+        const paymentIntentId = 'pi_for_refund_test';
+        const refundAmount = 1234;
+
+        async function callCreateRefund(reason?: string) {
+            const stripeService: StripeService = server.app.get(StripeService);
+            const orderService = server.app.get(OrderService);
+            const channelService = server.app.get(ChannelService);
+            const channel = await channelService.getDefaultChannel();
+            const ctx = new RequestContext({
+                apiType: 'admin',
+                isAuthorized: true,
+                authorizedAsOwnerOnly: false,
+                channel,
+                languageCode: LanguageCode.en,
+            });
+            const orders = await orderService.findAll(ctx, { take: 1 });
+            const realOrder = orders.items[0]!;
+            const syntheticPayment = { transactionId: paymentIntentId } as Payment;
+            return stripeService.createRefund(ctx, realOrder, syntheticPayment, refundAmount, reason);
+        }
+
+        it('forwards a Stripe-enum reason as the structured `reason` field', async () => {
+            let payload: Record<string, string> | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/refunds', body => {
+                    payload = body;
+                    return true;
+                })
+                .reply(200, { id: 're_test_enum', status: 'succeeded' });
+            // Reset the Japan channel back to the default before calling.
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await callCreateRefund('requested_by_customer');
+            expect(payload?.reason).toBe('requested_by_customer');
+            expect(payload?.['metadata[vendureRefundReason]']).toBeUndefined();
+        });
+
+        it('stores a non-enum reason on metadata.vendureRefundReason', async () => {
+            let payload: Record<string, string> | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/refunds', body => {
+                    payload = body;
+                    return true;
+                })
+                .reply(200, { id: 're_test_metadata', status: 'succeeded' });
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await callCreateRefund('customer-changed-mind');
+            expect(payload?.reason).toBeUndefined();
+            expect(payload?.['metadata[vendureRefundReason]']).toBe('customer-changed-mind');
+        });
+
+        it('forwards neither reason nor metadata when no reason is provided', async () => {
+            let payload: Record<string, string> | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/refunds', body => {
+                    payload = body;
+                    return true;
+                })
+                .reply(200, { id: 're_test_no_reason', status: 'succeeded' });
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await callCreateRefund(undefined);
+            expect(payload?.reason).toBeUndefined();
+            expect(payload?.['metadata[vendureRefundReason]']).toBeUndefined();
+        });
+
+        it('sends a deterministic idempotency key derived from payment intent + amount', async () => {
+            let capturedKey: string | string[] | undefined;
+            nock('https://api.stripe.com/')
+                .post('/v1/refunds')
+                .reply(function reply() {
+                    capturedKey = this.req.headers['idempotency-key'];
+                    return [200, { id: 're_idem', status: 'succeeded' }];
+                });
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await callCreateRefund('requested_by_customer');
+            expect(capturedKey).toBe(`refund_${paymentIntentId}_${refundAmount}`);
         });
     });
 });

--- a/packages/stripe-plugin/package.json
+++ b/packages/stripe-plugin/package.json
@@ -37,8 +37,8 @@
         "@vendure/common": "3.6.0-minor-202603280303",
         "@vendure/core": "3.6.0-minor-202603280303",
         "@vendure/testing": "3.6.0-minor-202603280303",
-        "nock": "^13.1.4",
-        "rimraf": "^5.0.5",
+        "nock": "^14.0.0",
+        "rimraf": "^6.0.0",
         "stripe": "^22.0.0",
         "typescript": "5.8.2"
     }

--- a/packages/stripe-plugin/package.json
+++ b/packages/stripe-plugin/package.json
@@ -31,7 +31,7 @@
     "peerDependencies": {
         "@vendure/core": "^3.6.0-0",
         "@vendure/common": "^3.6.0-0",
-        "stripe": "13.x"
+        "stripe": "^22.0.0"
     },
     "devDependencies": {
         "@vendure/common": "3.6.0-minor-202603280303",
@@ -39,7 +39,7 @@
         "@vendure/testing": "3.6.0-minor-202603280303",
         "nock": "^13.1.4",
         "rimraf": "^5.0.5",
-        "stripe": "^13.3.0",
+        "stripe": "^22.0.0",
         "typescript": "5.8.2"
     }
 }

--- a/packages/stripe-plugin/src/__type-checks.ts
+++ b/packages/stripe-plugin/src/__type-checks.ts
@@ -28,6 +28,8 @@ import type {
     StripeRefundCreateParams,
     StripeRequestOptions,
 } from './stripe-types';
+import Stripe from 'stripe';
+
 
 type Extends<A, B> = [A] extends [B] ? true : false;
 type Assert<T extends true> = T;
@@ -141,7 +143,6 @@ type _Event = Assert<
 type _ApiVersion = Assert<Extends<StripeLatestApiVersion, string>>;
 
 // HttpClient must remain a value Stripe.createFetchHttpClient() produces.
-import Stripe from 'stripe';
 type _HttpClient = Assert<Extends<ReturnType<typeof Stripe.createFetchHttpClient>, StripeHttpClient>>;
 
 // Silence "is declared but never used" for the assertion locals — they exist

--- a/packages/stripe-plugin/src/__type-checks.ts
+++ b/packages/stripe-plugin/src/__type-checks.ts
@@ -1,0 +1,160 @@
+/**
+ * Compile-time tripwire for the workarounds in `stripe-types.ts`.
+ *
+ * That file extracts namespace types from stripe-node's method signatures
+ * (a workaround for https://github.com/stripe/stripe-node/issues/2683 /
+ * https://github.com/stripe/stripe-node/pull/2725 — CJS+NodeNext doesn't
+ * expose the `Stripe.*` namespace via the default import).
+ *
+ * If a future stripe-node release reshapes the underlying method signatures
+ * — even subtly, e.g. by tightening overloads — the shimmed types here can
+ * drift silently. The assertions below pin the specific fields the plugin
+ * reads/writes against the shimmed types, so any drift breaks the build
+ * rather than the runtime.
+ *
+ * Delete this file when stripe-node#2725 ships and the shim itself can be
+ * deleted.
+ */
+import type {
+    StripeCustomerCreateParams,
+    StripeEvent,
+    StripeHttpClient,
+    StripeLatestApiVersion,
+    StripeMetadata,
+    StripeMetadataParam,
+    StripePaymentIntent,
+    StripePaymentIntentCreateParams,
+    StripeRefund,
+    StripeRefundCreateParams,
+    StripeRequestOptions,
+} from './stripe-types';
+
+type Extends<A, B> = [A] extends [B] ? true : false;
+type Assert<T extends true> = T;
+
+// PaymentIntent fields read by the plugin (controller + service).
+type _PaymentIntent = Assert<
+    Extends<StripePaymentIntent['id'], string> extends true
+        ? Extends<NonNullable<StripePaymentIntent['client_secret']>, string> extends true
+            ? Extends<StripePaymentIntent['amount_received'], number> extends true
+                ? Extends<StripePaymentIntent['status'], string> extends true
+                    ? Extends<NonNullable<StripePaymentIntent['metadata']>, Record<string, string>> extends true
+                        ? Extends<
+                              NonNullable<StripePaymentIntent['last_payment_error']>['message'],
+                              string | undefined
+                          > extends true
+                            ? true
+                            : false
+                        : false
+                    : false
+                : false
+            : false
+        : false
+>;
+
+// PaymentIntentCreateParams fields written by the plugin (service.createPaymentIntent).
+type _PaymentIntentCreateParams = Assert<
+    Extends<StripePaymentIntentCreateParams['amount'], number> extends true
+        ? Extends<StripePaymentIntentCreateParams['currency'], string> extends true
+            ? Extends<
+                  NonNullable<StripePaymentIntentCreateParams['automatic_payment_methods']>['enabled'],
+                  boolean
+              > extends true
+                ? Extends<
+                      NonNullable<StripePaymentIntentCreateParams['metadata']>,
+                      Record<string, string | number | null>
+                  > extends true
+                    ? true
+                    : false
+                : false
+            : false
+        : false
+>;
+
+// CustomerCreateParams fields written by the plugin (service.getStripeCustomerId).
+type _CustomerCreateParams = Assert<
+    Extends<NonNullable<StripeCustomerCreateParams['email']>, string> extends true
+        ? Extends<NonNullable<StripeCustomerCreateParams['name']>, string> extends true
+            ? true
+            : false
+        : false
+>;
+
+// Refund fields read by the handler (stripe.handler.createRefund).
+type _Refund = Assert<
+    // status must include the three values the handler switches on.
+    Extends<'succeeded', StripeRefund['status']> extends true
+        ? Extends<'pending', StripeRefund['status']> extends true
+            ? Extends<'failed', StripeRefund['status']> extends true
+                ? Extends<StripeRefund['failure_reason'], string | undefined | null> extends true
+                    ? true
+                    : false
+                : false
+            : false
+        : false
+>;
+
+// RefundCreateParams fields written by the plugin (service.createRefund).
+type _RefundCreateParams = Assert<
+    Extends<NonNullable<StripeRefundCreateParams['payment_intent']>, string> extends true
+        ? Extends<NonNullable<StripeRefundCreateParams['amount']>, number> extends true
+            ? // The structured reason enum must still accept the three values the service maps to.
+              Extends<'requested_by_customer', NonNullable<StripeRefundCreateParams['reason']>> extends true
+                ? Extends<'duplicate', NonNullable<StripeRefundCreateParams['reason']>> extends true
+                    ? Extends<'fraudulent', NonNullable<StripeRefundCreateParams['reason']>> extends true
+                        ? true
+                        : false
+                    : false
+                : false
+            : false
+        : false
+>;
+
+// RequestOptions fields used by the plugin (service.createPaymentIntent + .createRefund).
+type _RequestOptions = Assert<
+    Extends<NonNullable<StripeRequestOptions['idempotencyKey']>, string> extends true
+        ? Extends<NonNullable<StripeRequestOptions['stripeAccount']>, string> extends true
+            ? true
+            : false
+        : false
+>;
+
+// Metadata-shaped types must remain a string-keyed record.
+type _Metadata = Assert<
+    Extends<StripeMetadata, Record<string, string>> extends true
+        ? Extends<Record<string, string>, StripeMetadataParam> extends true
+            ? true
+            : false
+        : false
+>;
+
+// Event fields read by the controller.
+type _Event = Assert<
+    Extends<StripeEvent['type'], string> extends true
+        ? Extends<StripeEvent['id'], string> extends true
+            ? true
+            : false
+        : false
+>;
+
+// API version must remain a string literal so cast targets stay valid.
+type _ApiVersion = Assert<Extends<StripeLatestApiVersion, string>>;
+
+// HttpClient must remain a value Stripe.createFetchHttpClient() produces.
+import Stripe from 'stripe';
+type _HttpClient = Assert<Extends<ReturnType<typeof Stripe.createFetchHttpClient>, StripeHttpClient>>;
+
+// Silence "is declared but never used" for the assertion locals — they exist
+// for their compile-time effect only.
+export type {
+    _ApiVersion,
+    _CustomerCreateParams,
+    _Event,
+    _HttpClient,
+    _Metadata,
+    _PaymentIntent,
+    _PaymentIntentCreateParams,
+    _Refund,
+    _RefundCreateParams,
+    _RequestOptions,
+};

--- a/packages/stripe-plugin/src/index.ts
+++ b/packages/stripe-plugin/src/index.ts
@@ -1,1 +1,3 @@
 export { StripePlugin } from './stripe.plugin';
+export type { StripePluginOptions } from './types';
+export type { StripeHttpClient, StripeLatestApiVersion } from './stripe-types';

--- a/packages/stripe-plugin/src/metadata-sanitize.ts
+++ b/packages/stripe-plugin/src/metadata-sanitize.ts
@@ -1,4 +1,4 @@
-import Stripe from 'stripe';
+import { StripeMetadataParam } from './stripe-types';
 
 const MAX_KEYS = 50;
 const MAX_KEY_NAME_LENGTH = 40;
@@ -14,7 +14,7 @@ const MAX_VALUE_LENGTH = 500;
  * You can specify up to 50 keys, with key names up to 40 characters long and values up to 500 characters long.
  *
  */
-export function sanitizeMetadata(metadata: Stripe.MetadataParam) {
+export function sanitizeMetadata(metadata: StripeMetadataParam): StripeMetadataParam {
     if (typeof metadata !== 'object' && metadata !== null) return {};
 
     const keys = Object.keys(metadata)
@@ -22,12 +22,12 @@ export function sanitizeMetadata(metadata: Stripe.MetadataParam) {
         .filter(
             keyName => typeof metadata[keyName] !== 'string' || metadata[keyName].length <= MAX_VALUE_LENGTH,
         )
-        .slice(0, MAX_KEYS) as Array<keyof Stripe.MetadataParam>;
+        .slice(0, MAX_KEYS) as Array<keyof StripeMetadataParam>;
 
     const sanitizedMetadata = keys.reduce((obj, keyName) => {
         obj[keyName] = metadata[keyName];
         return obj;
-    }, {} as Stripe.MetadataParam);
+    }, {} as StripeMetadataParam);
 
     return sanitizedMetadata;
 }

--- a/packages/stripe-plugin/src/stripe-client.ts
+++ b/packages/stripe-plugin/src/stripe-client.ts
@@ -7,9 +7,14 @@ import { StripeHttpClient, StripeLatestApiVersion } from './stripe-types';
  *
  * `apiVersion` controls the Stripe API version sent with every request:
  *   - `undefined` (default) — use the SDK's pinned version (recommended).
- *   - a specific version string — pin to that version.
- *   - `null` — fall back to the Stripe account's default API version
- *     (pre-2.0.0 behaviour).
+ *   - a specific version string — pin to that version (cast to
+ *     `StripeLatestApiVersion`).
+ *
+ * Note: the underlying SDK coerces `null`/falsy to its pinned default
+ * (`stripe.core.js`: `props.apiVersion || DEFAULT_API_VERSION`), so there
+ * is no way to instruct it to omit the `Stripe-Version` header and use the
+ * Stripe account's default API version. This was true on stripe-node v13
+ * too, despite a misleading comment in the pre-2.0.0 plugin code.
  *
  * `httpClient` overrides the underlying HTTP transport. The default is
  * Stripe's fetch-based client (`globalThis.fetch`), which sidesteps a
@@ -21,14 +26,11 @@ export class VendureStripeClient extends Stripe {
     constructor(
         private apiKey: string,
         public webhookSecret: string,
-        apiVersion?: StripeLatestApiVersion | null,
+        apiVersion?: StripeLatestApiVersion,
         httpClient?: StripeHttpClient,
     ) {
         super(apiKey, {
-            apiVersion:
-                apiVersion === null
-                    ? (null as unknown as StripeLatestApiVersion)
-                    : apiVersion,
+            apiVersion,
             httpClient: httpClient ?? Stripe.createFetchHttpClient(),
         });
     }

--- a/packages/stripe-plugin/src/stripe-client.ts
+++ b/packages/stripe-plugin/src/stripe-client.ts
@@ -1,12 +1,14 @@
 import Stripe from 'stripe';
 
+import { StripeLatestApiVersion } from './stripe-types';
+
 /**
  * Wrapper around the Stripe client that exposes ApiKey and WebhookSecret
  */
 export class VendureStripeClient extends Stripe {
     constructor(private apiKey: string, public webhookSecret: string) {
         super(apiKey, {
-            apiVersion: null as unknown as Stripe.LatestApiVersion, // Use accounts default version
+            apiVersion: null as unknown as StripeLatestApiVersion, // Use accounts default version
         });
     }
 }

--- a/packages/stripe-plugin/src/stripe-client.ts
+++ b/packages/stripe-plugin/src/stripe-client.ts
@@ -10,6 +10,13 @@ import { StripeLatestApiVersion } from './stripe-types';
  *   - a specific version string — pin to that version.
  *   - `null` — fall back to the Stripe account's default API version
  *     (pre-2.0.0 behaviour).
+ *
+ * The underlying HTTP transport is Stripe's fetch-based client, using the
+ * platform's global `fetch` (Node 18+). This avoids a deadlock between
+ * Stripe's NodeHttpClient (which waits for the socket's `secureConnect`
+ * event before writing the request body) and modern HTTP mocking libraries
+ * such as nock@14 / @mswjs/interceptors, which only emit `secureConnect`
+ * once a request has been matched and responded to.
  */
 export class VendureStripeClient extends Stripe {
     constructor(
@@ -22,6 +29,7 @@ export class VendureStripeClient extends Stripe {
                 apiVersion === null
                     ? (null as unknown as StripeLatestApiVersion)
                     : apiVersion,
+            httpClient: Stripe.createFetchHttpClient(),
         });
     }
 }

--- a/packages/stripe-plugin/src/stripe-client.ts
+++ b/packages/stripe-plugin/src/stripe-client.ts
@@ -3,12 +3,25 @@ import Stripe from 'stripe';
 import { StripeLatestApiVersion } from './stripe-types';
 
 /**
- * Wrapper around the Stripe client that exposes ApiKey and WebhookSecret
+ * Wrapper around the Stripe client that exposes ApiKey and WebhookSecret.
+ *
+ * `apiVersion` controls the Stripe API version sent with every request:
+ *   - `undefined` (default) — use the SDK's pinned version (recommended).
+ *   - a specific version string — pin to that version.
+ *   - `null` — fall back to the Stripe account's default API version
+ *     (pre-2.0.0 behaviour).
  */
 export class VendureStripeClient extends Stripe {
-    constructor(private apiKey: string, public webhookSecret: string) {
+    constructor(
+        private apiKey: string,
+        public webhookSecret: string,
+        apiVersion?: StripeLatestApiVersion | null,
+    ) {
         super(apiKey, {
-            apiVersion: null as unknown as StripeLatestApiVersion, // Use accounts default version
+            apiVersion:
+                apiVersion === null
+                    ? (null as unknown as StripeLatestApiVersion)
+                    : apiVersion,
         });
     }
 }

--- a/packages/stripe-plugin/src/stripe-client.ts
+++ b/packages/stripe-plugin/src/stripe-client.ts
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 
-import { StripeLatestApiVersion } from './stripe-types';
+import { StripeHttpClient, StripeLatestApiVersion } from './stripe-types';
 
 /**
  * Wrapper around the Stripe client that exposes ApiKey and WebhookSecret.
@@ -11,25 +11,25 @@ import { StripeLatestApiVersion } from './stripe-types';
  *   - `null` — fall back to the Stripe account's default API version
  *     (pre-2.0.0 behaviour).
  *
- * The underlying HTTP transport is Stripe's fetch-based client, using the
- * platform's global `fetch` (Node 18+). This avoids a deadlock between
- * Stripe's NodeHttpClient (which waits for the socket's `secureConnect`
- * event before writing the request body) and modern HTTP mocking libraries
- * such as nock@14 / @mswjs/interceptors, which only emit `secureConnect`
- * once a request has been matched and responded to.
+ * `httpClient` overrides the underlying HTTP transport. The default is
+ * Stripe's fetch-based client (`globalThis.fetch`), which sidesteps a
+ * deadlock between Stripe's NodeHttpClient and modern HTTP mocking
+ * libraries (nock@14 / @mswjs/interceptors). Pass a NodeHttpClient with
+ * a custom `http.Agent` to route through a proxy or tune keep-alive.
  */
 export class VendureStripeClient extends Stripe {
     constructor(
         private apiKey: string,
         public webhookSecret: string,
         apiVersion?: StripeLatestApiVersion | null,
+        httpClient?: StripeHttpClient,
     ) {
         super(apiKey, {
             apiVersion:
                 apiVersion === null
                     ? (null as unknown as StripeLatestApiVersion)
                     : apiVersion,
-            httpClient: Stripe.createFetchHttpClient(),
+            httpClient: httpClient ?? Stripe.createFetchHttpClient(),
         });
     }
 }

--- a/packages/stripe-plugin/src/stripe-types.ts
+++ b/packages/stripe-plugin/src/stripe-types.ts
@@ -1,0 +1,29 @@
+/**
+ * Re-exports for Stripe namespace types that are unreachable via the default
+ * import under `moduleResolution: NodeNext` + CommonJS in stripe@22's d.ts
+ * shipping shape (see https://github.com/stripe/stripe-node/issues/2683 /
+ * https://github.com/stripe/stripe-node/pull/2725). The PR is not yet merged
+ * at the time of writing; once the upstream fix ships and we pin a version
+ * that includes it, the rest of the plugin can switch back to direct
+ * `Stripe.PaymentIntent`-style access and this file can be deleted.
+ */
+import type Stripe from 'stripe';
+
+type StripeInstance = Stripe.Stripe;
+
+export type StripePaymentIntent = Awaited<ReturnType<StripeInstance['paymentIntents']['create']>>;
+export type StripePaymentIntentCreateParams = NonNullable<
+    Parameters<StripeInstance['paymentIntents']['create']>[0]
+>;
+export type StripeCustomerCreateParams = NonNullable<
+    Parameters<StripeInstance['customers']['create']>[0]
+>;
+export type StripeRefund = Awaited<ReturnType<StripeInstance['refunds']['create']>>;
+export type StripeRefundCreateParams = NonNullable<Parameters<StripeInstance['refunds']['create']>[0]>;
+export type StripeRequestOptions = NonNullable<Parameters<StripeInstance['paymentIntents']['create']>[1]>;
+export type StripeMetadataParam = NonNullable<StripePaymentIntentCreateParams['metadata']>;
+export type StripeMetadata = NonNullable<StripePaymentIntent['metadata']>;
+export type StripeEvent = ReturnType<StripeInstance['webhooks']['constructEvent']>;
+export type StripeLatestApiVersion = NonNullable<
+    NonNullable<ConstructorParameters<typeof Stripe>[1]>['apiVersion']
+>;

--- a/packages/stripe-plugin/src/stripe-types.ts
+++ b/packages/stripe-plugin/src/stripe-types.ts
@@ -27,3 +27,6 @@ export type StripeEvent = ReturnType<StripeInstance['webhooks']['constructEvent'
 export type StripeLatestApiVersion = NonNullable<
     NonNullable<ConstructorParameters<typeof Stripe>[1]>['apiVersion']
 >;
+export type StripeHttpClient = NonNullable<
+    NonNullable<ConstructorParameters<typeof Stripe>[1]>['httpClient']
+>;

--- a/packages/stripe-plugin/src/stripe-utils.ts
+++ b/packages/stripe-plugin/src/stripe-utils.ts
@@ -1,5 +1,6 @@
 import { CurrencyCode, LanguageCode, Order } from '@vendure/core';
-import Stripe from 'stripe';
+
+import { StripeMetadata } from './stripe-types';
 
 /**
  * @description
@@ -42,7 +43,7 @@ function currencyHasFractionPart(currencyCode: CurrencyCode): boolean {
  * @description
  * Ensures that the payment intent metadata object contains the expected properties, as defined by the plugin.
  */
-export function isExpectedVendureStripeEventMetadata(metadata: Stripe.Metadata): metadata is {
+export function isExpectedVendureStripeEventMetadata(metadata: StripeMetadata): metadata is {
     channelToken: string;
     orderCode: string;
     orderId: string;

--- a/packages/stripe-plugin/src/stripe.controller.ts
+++ b/packages/stripe-plugin/src/stripe.controller.ts
@@ -13,9 +13,9 @@ import {
 } from '@vendure/core';
 import { OrderStateTransitionError } from '@vendure/core/dist/common/error/generated-graphql-shop-errors';
 import type { Response } from 'express';
-import type Stripe from 'stripe';
 
 import { loggerCtx, STRIPE_PLUGIN_OPTIONS } from './constants';
+import { StripeEvent, StripePaymentIntent } from './stripe-types';
 import { isExpectedVendureStripeEventMetadata } from './stripe-utils';
 import { stripePaymentMethodHandler } from './stripe.handler';
 import { StripeService } from './stripe.service';
@@ -50,8 +50,8 @@ export class StripeController {
             return;
         }
 
-        const event = JSON.parse(request.body.toString()) as Stripe.Event;
-        const paymentIntent = event.data.object as Stripe.PaymentIntent;
+        const event = JSON.parse(request.body.toString()) as StripeEvent;
+        const paymentIntent = event.data.object as StripePaymentIntent;
 
         if (!paymentIntent) {
             Logger.error(noPaymentIntentErrorMessage, loggerCtx);

--- a/packages/stripe-plugin/src/stripe.handler.ts
+++ b/packages/stripe-plugin/src/stripe.handler.ts
@@ -73,10 +73,8 @@ export const stripePaymentMethodHandler = new PaymentMethodHandler({
     },
 
     async createRefund(ctx, input, amount, order, payment, args): Promise<CreateRefundResult> {
-        // TODO: Consider passing the "reason" property once this feature request is addressed:
-        // https://github.com/vendurehq/vendure/issues/893
         try {
-            const refund = await stripeService.createRefund(ctx, order, payment, amount);
+            const refund = await stripeService.createRefund(ctx, order, payment, amount, input.reason);
             if (refund.status === 'succeeded') {
                 return {
                     state: 'Settled' as const,

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -153,7 +153,12 @@ export class StripeService {
         }
         const apiKey = this.findOrThrowArgValue(stripePaymentMethod.handler.args, 'apiKey');
         const webhookSecret = this.findOrThrowArgValue(stripePaymentMethod.handler.args, 'webhookSecret');
-        return new VendureStripeClient(apiKey, webhookSecret, this.options.apiVersion);
+        return new VendureStripeClient(
+            apiKey,
+            webhookSecret,
+            this.options.apiVersion,
+            this.options.httpClient,
+        );
     }
 
     private findOrThrowArgValue(args: ConfigArg[], name: string): string {

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -20,6 +20,13 @@ import { getAmountInStripeMinorUnits } from './stripe-utils';
 import { stripePaymentMethodHandler } from './stripe.handler';
 import { StripePluginOptions } from './types';
 
+const STRIPE_REFUND_REASONS = ['duplicate', 'fraudulent', 'requested_by_customer'] as const;
+type StripeRefundReason = (typeof STRIPE_REFUND_REASONS)[number];
+
+function isStripeRefundReason(reason: string | undefined): reason is StripeRefundReason {
+    return !!reason && (STRIPE_REFUND_REASONS as readonly string[]).includes(reason);
+}
+
 @Injectable()
 export class StripeService {
     constructor(
@@ -107,11 +114,18 @@ export class StripeService {
         order: Order,
         payment: Payment,
         amount: number,
+        reason?: string,
     ): Promise<StripeRefund> {
         const stripe = await this.getStripeClient(ctx, order);
-        return stripe.refunds.create({
+        const structuredReason = isStripeRefundReason(reason) ? reason : undefined;
+        const params: Parameters<typeof stripe.refunds.create>[0] = {
             payment_intent: payment.transactionId,
             amount,
+            ...(structuredReason ? { reason: structuredReason } : {}),
+            ...(reason && !structuredReason ? { metadata: { vendureRefundReason: reason } } : {}),
+        };
+        return stripe.refunds.create(params, {
+            idempotencyKey: `refund_${payment.transactionId}_${amount}`,
         });
     }
 

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -12,6 +12,7 @@ import {
     TransactionalConnection,
     UserInputError,
 } from '@vendure/core';
+
 import { loggerCtx, STRIPE_PLUGIN_OPTIONS } from './constants';
 import { sanitizeMetadata } from './metadata-sanitize';
 import { VendureStripeClient } from './stripe-client';

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -139,7 +139,7 @@ export class StripeService {
         }
         const apiKey = this.findOrThrowArgValue(stripePaymentMethod.handler.args, 'apiKey');
         const webhookSecret = this.findOrThrowArgValue(stripePaymentMethod.handler.args, 'webhookSecret');
-        return new VendureStripeClient(apiKey, webhookSecret);
+        return new VendureStripeClient(apiKey, webhookSecret, this.options.apiVersion);
     }
 
     private findOrThrowArgValue(args: ConfigArg[], name: string): string {

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -12,11 +12,10 @@ import {
     TransactionalConnection,
     UserInputError,
 } from '@vendure/core';
-import Stripe from 'stripe';
-
 import { loggerCtx, STRIPE_PLUGIN_OPTIONS } from './constants';
 import { sanitizeMetadata } from './metadata-sanitize';
 import { VendureStripeClient } from './stripe-client';
+import { StripeEvent, StripeRefund } from './stripe-types';
 import { getAmountInStripeMinorUnits } from './stripe-utils';
 import { stripePaymentMethodHandler } from './stripe.handler';
 import { StripePluginOptions } from './types';
@@ -98,7 +97,7 @@ export class StripeService {
         order: Order,
         payload: Buffer,
         signature: string,
-    ): Promise<Stripe.Event> {
+    ): Promise<StripeEvent> {
         const stripe = await this.getStripeClient(ctx, order);
         return stripe.webhooks.constructEvent(payload, signature, stripe.webhookSecret);
     }
@@ -108,7 +107,7 @@ export class StripeService {
         order: Order,
         payment: Payment,
         amount: number,
-    ): Promise<Stripe.Response<Stripe.Refund>> {
+    ): Promise<StripeRefund> {
         const stripe = await this.getStripeClient(ctx, order);
         return stripe.refunds.create({
             payment_intent: payment.transactionId,

--- a/packages/stripe-plugin/src/types.ts
+++ b/packages/stripe-plugin/src/types.ts
@@ -4,6 +4,7 @@ import type { Request } from 'express';
 
 import {
     StripeCustomerCreateParams,
+    StripeHttpClient,
     StripeLatestApiVersion,
     StripeMetadataParam,
     StripePaymentIntentCreateParams,
@@ -216,6 +217,32 @@ export interface StripePluginOptions {
      * @since 2.0.0
      */
     apiVersion?: StripeLatestApiVersion | null;
+
+    /**
+     * @description
+     * Override the HTTP client used to talk to Stripe. Defaults to Stripe's
+     * `FetchHttpClient` (using `globalThis.fetch`), which is what the plugin
+     * uses when this option is left unset. Override to inject a
+     * `NodeHttpClient` with a custom `http.Agent` if you need to route
+     * requests through a proxy, tune keep-alive behaviour, or otherwise
+     * customise the underlying TCP/TLS layer.
+     *
+     * @example
+     * ```ts
+     * import Stripe from 'stripe';
+     * import { HttpsProxyAgent } from 'https-proxy-agent';
+     *
+     * StripePlugin.init({
+     *     httpClient: Stripe.createNodeHttpClient(
+     *         new HttpsProxyAgent(process.env.HTTPS_PROXY!),
+     *     ),
+     * });
+     * ```
+     *
+     * @default undefined (Stripe.createFetchHttpClient())
+     * @since 2.0.0
+     */
+    httpClient?: StripeHttpClient;
 }
 
 export interface RequestWithRawBody extends Request {

--- a/packages/stripe-plugin/src/types.ts
+++ b/packages/stripe-plugin/src/types.ts
@@ -200,6 +200,22 @@ export interface StripePluginOptions {
      * to `true` to skip processing those payment intents.
      */
     skipPaymentIntentsWithoutExpectedMetadata?: boolean;
+
+    /**
+     * @description
+     * The Stripe API version to send with every request. Defaults to the version
+     * pinned by the SDK (currently `2026-05-27.dahlia`), matching the API the
+     * SDK's TypeScript types describe.
+     *
+     * Pass a specific version string (cast to `StripeLatestApiVersion`) to pin
+     * to a different version, or `null` to fall back to your Stripe account's
+     * default API version — this restores the pre-2.0.0 behaviour, but means
+     * the SDK types may not match what the API returns.
+     *
+     * @default undefined (SDK pinned version)
+     * @since 2.0.0
+     */
+    apiVersion?: StripeLatestApiVersion | null;
 }
 
 export interface RequestWithRawBody extends Request {

--- a/packages/stripe-plugin/src/types.ts
+++ b/packages/stripe-plugin/src/types.ts
@@ -1,7 +1,14 @@
 import type { Injector, Order, RequestContext } from '@vendure/core';
 import '@vendure/core/dist/entity/custom-entity-fields';
 import type { Request } from 'express';
-import type Stripe from 'stripe';
+
+import {
+    StripeCustomerCreateParams,
+    StripeLatestApiVersion,
+    StripeMetadataParam,
+    StripePaymentIntentCreateParams,
+    StripeRequestOptions,
+} from './stripe-types';
 
 // Note: deep import is necessary here because CustomCustomerFields is also extended in the Braintree
 // plugin. Reference: https://github.com/microsoft/TypeScript/issues/46617
@@ -12,12 +19,12 @@ declare module '@vendure/core/dist/entity/custom-entity-fields' {
 }
 
 type AdditionalPaymentIntentCreateParams = Partial<
-    Omit<Stripe.PaymentIntentCreateParams, 'amount' | 'currency' | 'customer'>
+    Omit<StripePaymentIntentCreateParams, 'amount' | 'currency' | 'customer'>
 >;
 
-type AdditionalRequestOptions = Partial<Omit<Stripe.RequestOptions, 'idempotencyKey'>>;
+type AdditionalRequestOptions = Partial<Omit<StripeRequestOptions, 'idempotencyKey'>>;
 
-type AdditionalCustomerCreateParams = Partial<Omit<Stripe.CustomerCreateParams, 'email'>>;
+type AdditionalCustomerCreateParams = Partial<Omit<StripeCustomerCreateParams, 'email'>>;
 
 /**
  * @description
@@ -71,7 +78,7 @@ export interface StripePluginOptions {
         injector: Injector,
         ctx: RequestContext,
         order: Order,
-    ) => Stripe.MetadataParam | Promise<Stripe.MetadataParam>;
+    ) => StripeMetadataParam | Promise<StripeMetadataParam>;
 
     /**
      * @description

--- a/packages/stripe-plugin/src/types.ts
+++ b/packages/stripe-plugin/src/types.ts
@@ -208,15 +208,15 @@ export interface StripePluginOptions {
      * pinned by the SDK (currently `2026-05-27.dahlia`), matching the API the
      * SDK's TypeScript types describe.
      *
-     * Pass a specific version string (cast to `StripeLatestApiVersion`) to pin
-     * to a different version, or `null` to fall back to your Stripe account's
-     * default API version — this restores the pre-2.0.0 behaviour, but means
-     * the SDK types may not match what the API returns.
+     * Override with an older version string (cast to `StripeLatestApiVersion`)
+     * if you can't yet upgrade your Stripe account to the SDK's pinned version
+     * and need the API to reply in the older shape. Note that the SDK's types
+     * will then diverge from the actual responses.
      *
      * @default undefined (SDK pinned version)
      * @since 2.0.0
      */
-    apiVersion?: StripeLatestApiVersion | null;
+    apiVersion?: StripeLatestApiVersion;
 
     /**
      * @description


### PR DESCRIPTION
Closes [OSS-555](https://linear.app/vendure/issue/OSS-555) — scoped to items **1, 2, 3, 6** (pure modernization). Items **4, 5, 7** (async/processing webhook, dashboard refund + dispute sync, SetupIntents) are deferred to follow-up issues.

## What's in this PR

| Commit | OSS-555 item | Summary |
|--------|--------------|---------|
| `bdc9035` | 1 | Stripe SDK `13.x` → `^22.0.0` peer + dev. Local `src/stripe-types.ts` shim works around [stripe-node#2683](https://github.com/stripe/stripe-node/issues/2683) (CJS NodeNext default import doesn't expose namespace types). |
| `e58cc1b` | 2 | `apiVersion` defaults to the SDK pinned version (`2026-05-27.dahlia`). New plugin option lets callers pin a specific version or set `null` to fall back to the Stripe account default (pre-2.0.0 behaviour). |
| `392a493` | 3 | `nock` 13 → 14, `rimraf` 5 → 6. `typescript` left at 5.8.2 (monorepo-pinned). |
| `6115123` | 6 | `createRefund` forwards Vendure's refund `reason` to Stripe (mapped to the enum where possible, otherwise stored on `metadata.vendureRefundReason`) and adds an idempotency key. |
| `e0a6606` | — | Tests adapted: switch `VendureStripeClient` to `Stripe.createFetchHttpClient()`. nock 14 (via `@mswjs/interceptors`) deadlocks Stripe's `NodeHttpClient` — see test plan below. |
| `a1381fc` | — | Hand-written 2.0.0 CHANGELOG section + README pointer. |

`feat!` on the apiVersion commit triggers the 2.0.0 major bump via the release flow.

## Verified

- `bun run build` clean across all 8 packages.
- `bun run lint` clean (0 errors, 12 pre-existing warnings).
- `bun run e2e` in `stripe-plugin`: 18/18 pass.

## Not test-covered — needs reviewer eyeball

These three behavioural changes are not covered by the existing e2e suite (the suite mocks Stripe entirely via nock):

1. **HTTP transport switched from `node:http(s)` to `fetch`.** Production users who inject a custom `http.Agent` (proxy, keep-alive tuning) will silently lose it. An `httpClient` escape hatch is planned as a follow-up commit on this PR.
2. **Default API version pinned to `dahlia`.** Stripe API responses on this account will now be shaped per the 2026-05-27 API. Per the Stripe changelog the core `PaymentIntent` / `Refund` / `Charge` / `Customer` shapes are stable between `2023-08-16` and `dahlia`, but this is unverified against a live account.
3. **Refund metadata fallback.** A non-Stripe-enum reason string ends up on `metadata.vendureRefundReason`, not the structured `reason` field.

---

## Confidence plan

### 1. Risk × evidence matrix

| Risk | What could break | Doc evidence | Verification plan |
|------|------------------|--------------|-------------------|
| Default API version moves `2023-08-16` → `2026-05-27.dahlia` (~3 years of evolution) | Field shapes on objects we touch (\`PaymentIntent\`, \`Refund\`, \`Charge\`, webhook \`Event\`) could shift. | Stripe's API changelog confirms that across \`2023-10-16\`, \`2024-04-10\`, \`2024-06-20\`, acacia (\`2024-09-30\`), basil (\`2025-03-31\`), clover and dahlia, **no breaking changes were made to the PaymentIntent / Refund / Charge / Customer shapes used by this plugin** — breaking changes in that window are scoped to Connect, Issuing, Terminal, Billing/Subscriptions, and Stripe.js method renames ([changelog/dahlia.md](https://docs.stripe.com/changelog/dahlia.md), [changelog/basil.md](https://docs.stripe.com/changelog/basil.md), [changelog/2024-06-20](https://docs.stripe.com/changelog/2024-06-20)). Only forward-compatible additions to enums like \`PaymentMethod.type\` (\`bizum\`, \`scalapay\`, \`sunbit\`, \`pix\`, etc., per stripe-node v22.1/22.2 changelog) — we don't switch on \`type\`, so this is moot for us. | (a) Walk the diff of \`node_modules/stripe/cjs/resources/{PaymentIntents,Refunds,Charges,Customers,Events}.d.ts\` against the same file in stripe@13.11.0 and confirm only additive changes touch the fields we read (\`id\`, \`client_secret\`, \`status\`, \`amount_received\`, \`last_payment_error.message\`, \`metadata\`, \`failure_reason\`). (b) During the manual walkthrough below, log the raw webhook payload and the \`paymentIntents.create\` response to confirm shape. |
| Webhook signature verification under new SDK | \`constructEvent\` could change semantics. | [webhooks/signatures](https://docs.stripe.com/webhooks/signatures): the v1 HMAC-SHA256 + \`Stripe-Signature\` scheme is **API-version-agnostic** and unchanged. stripe-node 22.0.1 only added \`string[]\` support to the signature param. Existing 18 e2e tests already exercise the signed and unsigned paths. | Already covered by \`e2e/stripe-payment.e2e-spec.ts\` ("Should not crash on signature validation failure", "Should validate the webhook's signature properly"). Verify in manual run with a *real* Stripe-signed webhook from \`stripe listen\`. |
| Webhook events for an older account API version still arrive in old shape | Even though we pin \`dahlia\` for outbound, inbound webhook events use the API version configured on the webhook endpoint at the Stripe dashboard (or the account default). A merchant on \`2023-08-16\` sends \`2023-08-16\`-shaped events. | [Stripe upgrades doc](https://docs.stripe.com/upgrades): events use the API version active at event creation; this is not affected by client \`apiVersion\`. The plugin only reads stable fields, so OK. | Manual walkthrough done twice: once with the Stripe account's default API version, once with the webhook endpoint pinned to a newer version (configurable in dashboard). |
| SDK v13 → v22 runtime contract | Removed callback support, ES6 class constructor, per-request host override removed, \`Stripe.errors.StripeError\` is now value-only. | stripe-node [v22 migration guide](https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v22) + local \`node_modules/stripe/CHANGELOG.md\` lines for 22.0.0. We don't use callbacks, host overrides, or per-request API keys; we already use \`new Stripe(...)\` and \`instanceof Stripe.errors.StripeError\` (value access, unaffected by the type-only change). | Build (passes) + e2e (18/18 pass). Add a unit-ish test that asserts \`Stripe.errors.StripeError\` is still a constructable class so a future SDK drift fails loudly. |
| NodeHttpClient → FetchHttpClient | Custom \`http.Agent\` settings (proxy, keep-alive tuning) injected via deployment can't be applied to FetchHttpClient. Retry/timeout behaviour and error shapes may differ. | stripe-node ships both clients (\`createFetchHttpClient\` is the documented Worker/Edge path, and the SDK supports it equivalently in Node since v18). The deadlock with nock@14 is documented in the @mswjs/interceptors socket lifecycle (\`mockConnect()\` runs inside \`respondWith()\` — \`connect\`/\`secureConnect\` only fire post-match, see \`node_modules/@mswjs/interceptors/lib/node/ClientRequest-*.cjs\`). | (a) Add a \`httpClient\` option to \`StripePluginOptions\` so users who *do* need an \`http.Agent\` can pass their own. (b) Document the migration in CHANGELOG (done). (c) Manual smoke test confirms a real card payment + a real refund both work end-to-end. (d) Add an automated test that asserts \`FetchHttpClient\` is wired by inspecting \`(stripe as any)._api.httpClient.getClientName() === 'fetch'\`. |
| Refund \`reason\` mapping | We map free-form Vendure refund reason strings onto Stripe's three-value enum \`duplicate \| fraudulent \| requested_by_customer\`; everything else goes to \`metadata.vendureRefundReason\`. | Stripe Refunds API reference: \`reason\` is a strict enum at the API level. [api/idempotent_requests](https://docs.stripe.com/api/idempotent_requests) confirms parameter mismatch on a replayed key returns an error — so the mapping has to be deterministic for the same input. Our mapping is. | Add unit-level test against \`StripeService.createRefund\` (mocked Stripe) for each of: enum-matching reason, non-matching reason, no reason. Also assert the request body forwarded to nock. |
| Refund idempotency key format | We use \`refund_{payment_intent_id}_{amount}\` — deterministic. Stripe recommends UUIDs but accepts any string ≤255 chars; parameter mismatch on replay errors. | [api/idempotent_requests](https://docs.stripe.com/api/idempotent_requests): "the idempotency layer compares incoming parameters to those of the original request and errors if they're not the same"; keys expire after ~24h. Our key intentionally encodes the unique parameters (PI + amount), so two identical retries replay safely; two *different* refunds for the same PI+amount within 24h would collide, but that's vanishingly rare for the same payment. | Add a unit-level test that fires \`createRefund\` twice with the same args and asserts both calls send the same \`Idempotency-Key\`. Document the 24h+identical-params rule in CHANGELOG. |
| \`stripe-types.ts\` shim fragility | We extract types via \`Parameters<typeof stripe.refunds.create>[0]\` etc. If stripe-node restructures method overloads, our types shift silently. | The shim documents that it's a workaround for [stripe-node#2683](https://github.com/stripe/stripe-node/issues/2683) / [PR #2725](https://github.com/stripe/stripe-node/pull/2725); once that lands and we pin the version we delete the shim. | (a) Add a CI tripwire — a \`.ts\` file with \`expectType<>\` assertions on each shimmed type so a stripe SDK upgrade fails the build instead of silently changing meaning. (b) Watch the PR for merge; open a follow-up Linear issue to delete the shim when ready. |
| nock@14 / @mswjs/interceptors socket semantics | The mock's \`connect\`/\`secureConnect\` events only fire after \`respondWith()\` runs, deadlocking any client that gates body writes on \`secureConnect\`. Stripe's \`NodeHttpClient\` does that. | Source-confirmed: \`node_modules/@mswjs/interceptors/lib/node/ClientRequest-*.cjs::mockConnect()\` is only called from \`respondWith()\`. nock@14 [release notes](https://github.com/nock/nock/releases/tag/v14.0.0) only call out "drop Node <18" and "support for native fetch" as breaking — the socket lifecycle change isn't called out. | FetchHttpClient sidesteps it. Test suite proves it (18/18). |

### 2. Pre-merge actions (in order)

- [ ] **Fix \`e2e/stripe-dev-server.ts\`** — currently broken pre-existing TS errors (\`@vendure/admin-ui-plugin\` import, stale codegen exports). Without this we can't actually run the dev server, which is the *only* way to exercise real Stripe + real webhook.
- [ ] **Manual walkthrough** against a Stripe test account:
  - \`stripe listen --forward-to localhost:3000/payments/stripe\` (webhook signing secret goes into the plugin config).
  - **Happy path** — create order, request payment intent, pay with \`4242 4242 4242 4242\`, confirm order transitions to \`PaymentSettled\`, payment record's \`transactionId\` matches the PI id.
  - **Decline path** — pay with \`4000 0000 0000 0002\`. Confirm \`payment_intent.payment_failed\` is logged but order doesn't transition (matches today's behaviour; item 4 of OSS-555 fixes the surrounding gap separately).
  - **Refund path** — admin UI refunds the settled payment with a reason (test both a \`requested_by_customer\` string and a custom string). Confirm Stripe dashboard shows the refund with the right \`reason\` field and \`vendureRefundReason\` metadata respectively.
  - **Idempotency** — manually retry the refund call and confirm Stripe returns the same refund (idempotent replay), not a duplicate.
  - **apiVersion override** — restart with \`apiVersion: null\` set. Confirm requests go out without a \`Stripe-Version\` header (visible in \`stripe listen\` output). Then with \`apiVersion: '2024-06-20' as any\` — confirm header reflects it.
  - **Webhook payload shape** — log one full webhook payload in each run; eyeball that the fields the controller reads (\`id\`, \`metadata.{channelToken,orderId,orderCode,languageCode}\`, \`amount_received\`, \`status\`, \`last_payment_error?.message\`) are present and shaped as expected.
- [ ] **Add three targeted automated tests**:
  - \`createRefund\` forwards \`reason: 'requested_by_customer'\` when the input matches a Stripe enum value, and \`metadata.vendureRefundReason\` when it doesn't.
  - \`createRefund\` calls Stripe with the deterministic idempotency key (assert the \`Idempotency-Key\` header captured by nock).
  - \`apiVersion: null\` results in no \`Stripe-Version\` header sent; \`apiVersion: 'X'\` results in \`Stripe-Version: X\`.
- [ ] **Type-shim tripwire** — \`src/__type-checks.ts\` with \`expectAssignable<>\` asserts pinning a representative field on each shimmed type. Future SDK drift breaks the build instead of silently shifting meaning.
- [ ] **\`httpClient\` plugin option escape hatch** for production users who need an \`http.Agent\`. Default stays \`createFetchHttpClient()\`; if set, pass through.
- [ ] **Diff stripe@13.11.0 vs stripe@22.2.0 d.ts shapes** for: \`Charge\`, \`Refund\`, \`PaymentIntent\`, \`PaymentIntentCreateParams\`, \`Refund.status\`, \`Refund.failure_reason\`. Confirm fields the plugin reads are still defined the same way.

### 3. Post-merge

- Open follow-up Linear issues for: Items 4–7 of OSS-555; delete the type shim once [stripe-node#2725](https://github.com/stripe/stripe-node/pull/2725) ships; consider re-adding NodeHttpClient as the default once nock fixes the socket lifecycle.

### 4. Remaining assumptions after this plan

- Behaviour against payment methods we don't have test card numbers for in the walkthrough (BNPL, SEPA, bank transfer). Items 4–7 of OSS-555 are scoped to add coverage there.
- \`FetchHttpClient\` retry / timeout / connection-pool behaviour at high concurrency. We're trusting Stripe's own implementation; this is the same SDK code Stripe ships for Workers and Edge, so it has production miles, just not under this exact codepath.
- Subtle webhook payload differences between API versions that don't break our code today but might if Stripe later removes a field still hidden in test fixtures (the mocked webhook payloads in our tests are forged, not captured from real Stripe).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/community-plugins/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783519280&installation_id=128408429&pr_number=36&repository=vendurehq%2Fcommunity-plugins&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fcommunity-plugins%2Fpull%2F36&signature=277b93e9ff528f11307a383d7412840b41b0b10259288fc6a8358c189e005eaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->