### PR TITLE
fix(stripe-plugin): pass requestOptions to customer list/create calls

### DIFF
--- a/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { CurrencyCode, LanguageCode } from '@vendure/common/lib/generated-types';
-import { EntityHydrator, mergeConfig } from '@vendure/core';
+import { Customer, EntityHydrator, mergeConfig, TransactionalConnection } from '@vendure/core';
 import {
     createProductDocument,
     createProductVariantsDocument,
@@ -326,6 +326,50 @@ describe('Stripe payments', () => {
             description: `Description for ${activeOrder!.customer!.emailAddress}`,
             phone: '12345',
         });
+    });
+
+    // https://github.com/vendurehq/community-plugins/issues/25
+    it('should pass requestOptions to customer list and create calls', async () => {
+        StripePlugin.options.requestOptions = () => ({
+            stripeAccount: 'acct_connected',
+        });
+
+        // Reset the cached Stripe customer id so the lookup/create path runs again.
+        const connection = server.app.get(TransactionalConnection);
+        const customerRepo = connection.rawConnection.getRepository(Customer);
+        const dbCustomer = await customerRepo.findOneByOrFail({
+            emailAddress: customers[1].emailAddress,
+        });
+        dbCustomer.customFields.stripeCustomerId = '';
+        await customerRepo.save(dbCustomer, { reload: false });
+
+        await shopClient.asUserWithCredentials(customers[1].emailAddress, 'test');
+
+        // Both customer calls must carry the Stripe-Account header, otherwise the
+        // customer is created on the platform account while the payment intent
+        // targets the connected account ("No such customer" on intent creation).
+        const stripeAccountHeaders: string[] = [];
+        nock('https://api.stripe.com/', {
+            reqheaders: {
+                'Stripe-Account': headerValue => {
+                    stripeAccountHeaders.push(headerValue);
+                    return true;
+                },
+            },
+        })
+            .get(/\/v1\/customers.*/)
+            .reply(200, { data: [] })
+            .post('/v1/customers')
+            .reply(201, { id: 'connected-account-customer-id' });
+        nock('https://api.stripe.com/').post('/v1/payment_intents').reply(200, {
+            client_secret: 'test-client-secret',
+        });
+
+        const { createStripePaymentIntent } = await shopClient.query(createStripePaymentIntentDocument);
+        expect(stripeAccountHeaders).toEqual(['acct_connected', 'acct_connected']);
+        expect(createStripePaymentIntent).toEqual('test-client-secret');
+        StripePlugin.options.requestOptions = undefined;
+        StripePlugin.options.customerCreateParams = undefined;
     });
 
     // https://github.com/vendurehq/vendure/issues/2450

--- a/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
+++ b/packages/stripe-plugin/e2e/stripe-payment.e2e-spec.ts
@@ -278,7 +278,7 @@ describe('Stripe payments', () => {
         });
         expect(connectedAccountHeader).toEqual('acct_connected');
         expect(createStripePaymentIntent).toEqual('test-client-secret');
-        StripePlugin.options.paymentIntentCreateParams = undefined;
+        StripePlugin.options.requestOptions = undefined;
     });
 
     // https://github.com/vendurehq/vendure/issues/2412
@@ -340,7 +340,7 @@ describe('Stripe payments', () => {
         const dbCustomer = await customerRepo.findOneByOrFail({
             emailAddress: customers[1].emailAddress,
         });
-        dbCustomer.customFields.stripeCustomerId = '';
+        dbCustomer.customFields.stripeCustomerId = null;
         await customerRepo.save(dbCustomer, { reload: false });
 
         await shopClient.asUserWithCredentials(customers[1].emailAddress, 'test');

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -179,7 +179,25 @@ export class StripeService {
 
         let stripeCustomerId;
 
-        const stripeCustomers = await stripe.customers.list({ email: customer.emailAddress });
+        // Resolve requestOptions the same way as createPaymentIntent() does, so that
+        // customer lookup/creation runs against the same Stripe account as the
+        // PaymentIntent (e.g. a connected account when `stripeAccount` is set).
+        // Note: the Stripe SDK rejects an empty options hash, so it is only passed
+        // along when it actually contains options.
+        const additionalOptions = await this.options.requestOptions?.(
+            new Injector(this.moduleRef),
+            ctx,
+            order,
+        );
+        const customerRequestOptions =
+            additionalOptions && Object.keys(additionalOptions).length > 0
+                ? additionalOptions
+                : undefined;
+
+        const customerListParams = { email: customer.emailAddress };
+        const stripeCustomers = customerRequestOptions
+            ? await stripe.customers.list(customerListParams, customerRequestOptions)
+            : await stripe.customers.list(customerListParams);
         if (stripeCustomers.data.length > 0) {
             stripeCustomerId = stripeCustomers.data[0].id;
         } else {
@@ -188,14 +206,17 @@ export class StripeService {
                 ctx,
                 order,
             );
-            const newStripeCustomer = await stripe.customers.create({
+            const customerCreateParams = {
                 email: customer.emailAddress,
                 name: `${customer.firstName} ${customer.lastName}`,
                 ...(additionalParams ?? {}),
                 ...(additionalParams?.metadata
                     ? { metadata: sanitizeMetadata(additionalParams.metadata) }
                     : {}),
-            });
+            };
+            const newStripeCustomer = customerRequestOptions
+                ? await stripe.customers.create(customerCreateParams, customerRequestOptions)
+                : await stripe.customers.create(customerCreateParams);
 
             stripeCustomerId = newStripeCustomer.id;
 

--- a/packages/stripe-plugin/src/stripe.service.ts
+++ b/packages/stripe-plugin/src/stripe.service.ts
@@ -33,18 +33,14 @@ export class StripeService {
     async createPaymentIntent(ctx: RequestContext, order: Order): Promise<string> {
         let customerId: string | undefined;
         const stripe = await this.getStripeClient(ctx, order);
+        const requestOptions = await this.resolveRequestOptions(ctx, order);
 
         if (this.options.storeCustomersInStripe && ctx.activeUserId) {
-            customerId = await this.getStripeCustomerId(ctx, order);
+            customerId = await this.getStripeCustomerId(ctx, order, requestOptions);
         }
         const amountInMinorUnits = getAmountInStripeMinorUnits(order);
 
         const additionalParams = await this.options.paymentIntentCreateParams?.(
-            new Injector(this.moduleRef),
-            ctx,
-            order,
-        );
-        const additionalOptions = await this.options.requestOptions?.(
             new Injector(this.moduleRef),
             ctx,
             order,
@@ -77,7 +73,7 @@ export class StripeService {
             },
             {
                 idempotencyKey: `${order.code}_${amountInMinorUnits}`,
-                ...(additionalOptions ?? {}),
+                ...(requestOptions ?? {}),
             },
         );
 
@@ -152,11 +148,34 @@ export class StripeService {
     }
 
     /**
+     * Resolves the optional per-request options (e.g. a `stripeAccount` targeting a
+     * connected account). Returns `undefined` when no callback is configured or it
+     * yields an empty object, because the Stripe SDK rejects an empty options hash.
+     */
+    private async resolveRequestOptions(
+        ctx: RequestContext,
+        order: Order,
+    ): Promise<Stripe.RequestOptions | undefined> {
+        const additionalOptions = await this.options.requestOptions?.(
+            new Injector(this.moduleRef),
+            ctx,
+            order,
+        );
+        return additionalOptions && Object.keys(additionalOptions).length > 0
+            ? additionalOptions
+            : undefined;
+    }
+
+    /**
      * Returns the stripeCustomerId if the Customer has one. If that's not the case, queries Stripe to check
      * if the customer is already registered, in which case it saves the id as stripeCustomerId and returns it.
      * Otherwise, creates a new Customer record in Stripe and returns the generated id.
      */
-    private async getStripeCustomerId(ctx: RequestContext, activeOrder: Order): Promise<string | undefined> {
+    private async getStripeCustomerId(
+        ctx: RequestContext,
+        activeOrder: Order,
+        requestOptions?: Stripe.RequestOptions,
+    ): Promise<string | undefined> {
         const [stripe, order] = await Promise.all([
             this.getStripeClient(ctx, activeOrder),
             // Load relation with customer not available in the response from activeOrderService.getOrderFromContext()
@@ -179,25 +198,14 @@ export class StripeService {
 
         let stripeCustomerId;
 
-        // Resolve requestOptions the same way as createPaymentIntent() does, so that
-        // customer lookup/creation runs against the same Stripe account as the
-        // PaymentIntent (e.g. a connected account when `stripeAccount` is set).
-        // Note: the Stripe SDK rejects an empty options hash, so it is only passed
-        // along when it actually contains options.
-        const additionalOptions = await this.options.requestOptions?.(
-            new Injector(this.moduleRef),
-            ctx,
-            order,
+        // The customer lookup and creation must hit the same Stripe account as the
+        // PaymentIntent. When `requestOptions` carries a `stripeAccount`, omitting it
+        // here would create the customer on the platform account while the intent
+        // targets the connected account, surfacing as "No such customer".
+        const stripeCustomers = await stripe.customers.list(
+            { email: customer.emailAddress },
+            requestOptions,
         );
-        const customerRequestOptions =
-            additionalOptions && Object.keys(additionalOptions).length > 0
-                ? additionalOptions
-                : undefined;
-
-        const customerListParams = { email: customer.emailAddress };
-        const stripeCustomers = customerRequestOptions
-            ? await stripe.customers.list(customerListParams, customerRequestOptions)
-            : await stripe.customers.list(customerListParams);
         if (stripeCustomers.data.length > 0) {
             stripeCustomerId = stripeCustomers.data[0].id;
         } else {
@@ -206,17 +214,17 @@ export class StripeService {
                 ctx,
                 order,
             );
-            const customerCreateParams = {
-                email: customer.emailAddress,
-                name: `${customer.firstName} ${customer.lastName}`,
-                ...(additionalParams ?? {}),
-                ...(additionalParams?.metadata
-                    ? { metadata: sanitizeMetadata(additionalParams.metadata) }
-                    : {}),
-            };
-            const newStripeCustomer = customerRequestOptions
-                ? await stripe.customers.create(customerCreateParams, customerRequestOptions)
-                : await stripe.customers.create(customerCreateParams);
+            const newStripeCustomer = await stripe.customers.create(
+                {
+                    email: customer.emailAddress,
+                    name: `${customer.firstName} ${customer.lastName}`,
+                    ...(additionalParams ?? {}),
+                    ...(additionalParams?.metadata
+                        ? { metadata: sanitizeMetadata(additionalParams.metadata) }
+                        : {}),
+                },
+                requestOptions,
+            );
 
             stripeCustomerId = newStripeCustomer.id;
 


### PR DESCRIPTION
## Problem

With `storeCustomersInStripe: true` and a `requestOptions` callback that scopes calls to a connected account (`stripeAccount`), `createPaymentIntent()` passes the options to `paymentIntents.create()`, but `getStripeCustomerId()` does not pass them to `customers.list()` / `customers.create()`. The customer is looked up/created on the **platform** account while the PaymentIntent targets the **connected** account, so intent creation fails with `No such customer: 'cus_...'`.

The platform-scoped id is then cached on `customer.customFields.stripeCustomerId`, so every subsequent attempt fails as well — manually clearing the field doesn't help, because the next lookup re-fetches the same platform customer by email and writes it back.

## Fix

Resolve `requestOptions` in `getStripeCustomerId()` the same way `createPaymentIntent()` does and pass them to both customer calls. The options hash is only passed when non-empty, because the Stripe SDK rejects an empty options object (`isOptionsHash` requires at least one known key).

## Testing

- New e2e test asserting that both customer calls carry the `Stripe-Account` header (red without the fix — nock doesn't match the requests).
- Full stripe-plugin e2e suite passes (19/19); lint introduces no new warnings.
- Verified end-to-end against a real Stripe sandbox using Connect: logged-in customer, Payment Element renders, payment settles via webhook on the connected account.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/community-plugins/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783870087&installation_id=128408429&pr_number=38&repository=vendurehq%2Fcommunity-plugins&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fcommunity-plugins%2Fpull%2F38&signature=3a22a880fa7fb4849b998a289925ab8f69bc6110fc00ad4ae6aa7d129fd914d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->