### PR TITLE
fix(braintree-plugin): return object metadata when gateway rejects without transaction

### DIFF
--- a/packages/braintree-plugin/package.json
+++ b/packages/braintree-plugin/package.json
@@ -18,7 +18,8 @@
         "build": "rimraf lib && tsc -p ./tsconfig.build.json",
         "lint": "eslint .",
         "ci": "npm run build",
-        "dev-server": "npm run build && DB=sqlite node -r ts-node/register e2e/braintree-dev-server.ts"
+        "dev-server": "npm run build && DB=sqlite node -r ts-node/register e2e/braintree-dev-server.ts",
+        "test": "vitest --run"
     },
     "homepage": "https://www.vendure.io/",
     "funding": "https://github.com/sponsors/michaelbromley",

--- a/packages/braintree-plugin/package.json
+++ b/packages/braintree-plugin/package.json
@@ -33,6 +33,7 @@
         "braintree": "3.x"
     },
     "devDependencies": {
+        "@nestjs/testing": "^11.1.13",
         "@types/braintree": "^3.3.11",
         "@vendure/common": "3.6.0-minor-202603280303",
         "@vendure/core": "3.6.0-minor-202603280303",

--- a/packages/braintree-plugin/src/braintree.handler.spec.ts
+++ b/packages/braintree-plugin/src/braintree.handler.spec.ts
@@ -1,0 +1,103 @@
+import { Injector } from '@vendure/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getGateway } from './braintree-common';
+import { braintreePaymentMethodHandler } from './braintree.handler';
+import { BRAINTREE_PLUGIN_OPTIONS } from './constants';
+
+vi.mock('./braintree-common', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./braintree-common')>();
+    return {
+        ...actual,
+        getGateway: vi.fn(),
+    };
+});
+
+const saleMock = vi.fn();
+
+function initHandler(pluginOptions: Record<string, any>) {
+    const fakeService = { hydrate: vi.fn().mockResolvedValue(undefined) };
+    const fakeModuleRef = {
+        get: (token: any) => (token === BRAINTREE_PLUGIN_OPTIONS ? pluginOptions : fakeService),
+    };
+    void braintreePaymentMethodHandler.init(new Injector(fakeModuleRef as any));
+}
+
+function createPayment() {
+    return braintreePaymentMethodHandler.createPayment(
+        {} as any,
+        { code: 'T_1', currencyCode: 'GBP' } as any,
+        4828,
+        [
+            { name: 'merchantId', value: 'merchant' },
+            { name: 'publicKey', value: 'public' },
+            { name: 'privateKey', value: 'private' },
+        ],
+        { nonce: 'fake-nonce' },
+        {} as any,
+    );
+}
+
+describe('braintreePaymentMethodHandler', () => {
+    beforeEach(() => {
+        saleMock.mockReset();
+        vi.mocked(getGateway).mockReturnValue({ transaction: { sale: saleMock } } as any);
+        initHandler({ storeCustomersInBraintree: false });
+    });
+
+    it('returns Declined with object metadata when the gateway rejects without a transaction', async () => {
+        // Validation-class rejections (invalid customer id, consumed nonce, 3DS
+        // amount mismatch) carry no transaction object in the response.
+        saleMock.mockResolvedValue({ success: false, message: 'Customer ID is invalid.' });
+
+        const result = await createPayment();
+
+        expect(result.state).toBe('Declined');
+        expect(result.errorMessage).toBe('Customer ID is invalid.');
+        // Payment.metadata is a non-nullable column: undefined here crashes the
+        // payment insert and surfaces a raw DB error to the customer.
+        expect(result.metadata).toEqual({});
+    });
+
+    it('returns Declined with extracted metadata when the gateway declines with a transaction', async () => {
+        saleMock.mockResolvedValue({
+            success: false,
+            message: 'Processor Declined',
+            transaction: { id: 'tx_declined', status: 'processor_declined' },
+        });
+
+        const result = await createPayment();
+
+        expect(result.state).toBe('Declined');
+        expect(result.transactionId).toBe('tx_declined');
+        expect(result.metadata).toMatchObject({ status: 'processor_declined' });
+    });
+
+    it('returns Settled with extracted metadata on success', async () => {
+        saleMock.mockResolvedValue({
+            success: true,
+            transaction: { id: 'tx_ok', status: 'submitted_for_settlement' },
+        });
+
+        const result = await createPayment();
+
+        expect(result.state).toBe('Settled');
+        expect(result.transactionId).toBe('tx_ok');
+        expect(result.metadata).toMatchObject({ status: 'submitted_for_settlement' });
+    });
+
+    it('applies a custom extractMetadata function', async () => {
+        initHandler({
+            storeCustomersInBraintree: false,
+            extractMetadata: (transaction: any) => ({ txStatus: transaction.status }),
+        });
+        saleMock.mockResolvedValue({
+            success: true,
+            transaction: { id: 'tx_ok', status: 'authorized' },
+        });
+
+        const result = await createPayment();
+
+        expect(result.metadata).toEqual({ txStatus: 'authorized' });
+    });
+});

--- a/packages/braintree-plugin/src/braintree.handler.spec.ts
+++ b/packages/braintree-plugin/src/braintree.handler.spec.ts
@@ -1,11 +1,13 @@
-import { Injector } from '@vendure/core';
+import { ModuleRef } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { EntityHydrator, Injector, TransactionalConnection } from '@vendure/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getGateway } from './braintree-common';
 import { braintreePaymentMethodHandler } from './braintree.handler';
 import { BRAINTREE_PLUGIN_OPTIONS } from './constants';
 
-vi.mock('./braintree-common', async (importOriginal) => {
+vi.mock('./braintree-common', async importOriginal => {
     const actual = await importOriginal<typeof import('./braintree-common')>();
     return {
         ...actual,
@@ -15,12 +17,16 @@ vi.mock('./braintree-common', async (importOriginal) => {
 
 const saleMock = vi.fn();
 
-function initHandler(pluginOptions: Record<string, any>) {
-    const fakeService = { hydrate: vi.fn().mockResolvedValue(undefined) };
-    const fakeModuleRef = {
-        get: (token: any) => (token === BRAINTREE_PLUGIN_OPTIONS ? pluginOptions : fakeService),
-    };
-    void braintreePaymentMethodHandler.init(new Injector(fakeModuleRef as any));
+async function initHandler(pluginOptions: Record<string, any>) {
+    const entityHydrator = { hydrate: vi.fn().mockResolvedValue(undefined) };
+    const moduleRef = await Test.createTestingModule({
+        providers: [
+            { provide: BRAINTREE_PLUGIN_OPTIONS, useValue: pluginOptions },
+            { provide: TransactionalConnection, useValue: {} },
+            { provide: EntityHydrator, useValue: entityHydrator },
+        ],
+    }).compile();
+    await braintreePaymentMethodHandler.init(new Injector(moduleRef.get(ModuleRef)));
 }
 
 function createPayment() {
@@ -39,10 +45,10 @@ function createPayment() {
 }
 
 describe('braintreePaymentMethodHandler', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         saleMock.mockReset();
         vi.mocked(getGateway).mockReturnValue({ transaction: { sale: saleMock } } as any);
-        initHandler({ storeCustomersInBraintree: false });
+        await initHandler({ storeCustomersInBraintree: false });
     });
 
     it('returns Declined with object metadata when the gateway rejects without a transaction', async () => {
@@ -54,8 +60,6 @@ describe('braintreePaymentMethodHandler', () => {
 
         expect(result.state).toBe('Declined');
         expect(result.errorMessage).toBe('Customer ID is invalid.');
-        // Payment.metadata is a non-nullable column: undefined here crashes the
-        // payment insert and surfaces a raw DB error to the customer.
         expect(result.metadata).toEqual({});
     });
 
@@ -87,7 +91,7 @@ describe('braintreePaymentMethodHandler', () => {
     });
 
     it('applies a custom extractMetadata function', async () => {
-        initHandler({
+        await initHandler({
             storeCustomersInBraintree: false,
             extractMetadata: (transaction: any) => ({ txStatus: transaction.status }),
         });
@@ -99,5 +103,20 @@ describe('braintreePaymentMethodHandler', () => {
         const result = await createPayment();
 
         expect(result.metadata).toEqual({ txStatus: 'authorized' });
+    });
+
+    it('falls back to object metadata when a custom extractMetadata returns null', async () => {
+        await initHandler({
+            storeCustomersInBraintree: false,
+            extractMetadata: () => null as any,
+        });
+        saleMock.mockResolvedValue({
+            success: true,
+            transaction: { id: 'tx_ok', status: 'authorized' },
+        });
+
+        const result = await createPayment();
+
+        expect(result.metadata).toEqual({});
     });
 });

--- a/packages/braintree-plugin/src/braintree.handler.ts
+++ b/packages/braintree-plugin/src/braintree.handler.ts
@@ -112,7 +112,11 @@ async function processPayment(
         },
     });
     const extractMetadataFn = pluginOptions.extractMetadata ?? defaultExtractMetadataFn;
-    const metadata = response.transaction && extractMetadataFn(response.transaction);
+    // Gateway rejections of the validation class (e.g. invalid customer id, consumed
+    // nonce, 3DS amount mismatch) carry no transaction object. Metadata must still be
+    // an object: Payment.metadata is a non-nullable column, so returning undefined
+    // here crashes the payment insert and masks the real gateway message.
+    const metadata = response.transaction ? extractMetadataFn(response.transaction) : {};
     if (!response.success) {
         return {
             amount,

--- a/packages/braintree-plugin/src/braintree.handler.ts
+++ b/packages/braintree-plugin/src/braintree.handler.ts
@@ -112,11 +112,8 @@ async function processPayment(
         },
     });
     const extractMetadataFn = pluginOptions.extractMetadata ?? defaultExtractMetadataFn;
-    // Gateway rejections of the validation class (e.g. invalid customer id, consumed
-    // nonce, 3DS amount mismatch) carry no transaction object. Metadata must still be
-    // an object: Payment.metadata is a non-nullable column, so returning undefined
-    // here crashes the payment insert and masks the real gateway message.
-    const metadata = response.transaction ? extractMetadataFn(response.transaction) : {};
+    // Payment.metadata is a non-nullable column.
+    const metadata = (response.transaction && extractMetadataFn(response.transaction)) ?? {};
     if (!response.success) {
         return {
             amount,

--- a/packages/braintree-plugin/tsconfig.build.json
+++ b/packages/braintree-plugin/tsconfig.build.json
@@ -3,5 +3,10 @@
     "compilerOptions": {
         "outDir": "./lib"
     },
-    "include": ["./src/**/*.ts"]
+    "include": [
+        "./src/**/*.ts"
+    ],
+    "exclude": [
+        "./src/**/*.spec.ts"
+    ]
 }


### PR DESCRIPTION
## Problem

When `gateway.transaction.sale()` is rejected at the validation level — invalid vaulted customer id, consumed/expired nonce, 3-D Secure amount mismatch — the response contains no `transaction` object. In that case `processPayment` computes

```ts
const metadata = response.transaction && extractMetadataFn(response.transaction);
```

which evaluates to `undefined`. Vendure's `PaymentService.createPayment` passes the handler result straight into `new Payment(...)`, and `Payment.metadata` is a non-nullable `simple-json` column, so the INSERT fails:

```
null value in column "metadata" of relation "payment" violates not-null constraint
```

Observed consequences in production:
- The customer sees the raw constraint-violation message instead of the actual gateway decline reason (e.g. "Customer ID is invalid."), which is swallowed.
- No payment row is recorded at all, so declined attempts of this class are invisible to any payment-attempt accounting built on top of the payments table.

## Fix

Default `metadata` to `{}` when the response carries no transaction. The failure then flows through the normal `Declined` path with `errorMessage: response.message` intact.

## Tests

Added `braintree.handler.spec.ts` covering the no-transaction rejection (fails against the previous implementation), decline-with-transaction, success, and custom `extractMetadata`. Wired `vitest --run` into the package (matching pub-sub-plugin) and excluded specs from the build tsconfig.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/community-plugins/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785653502&installation_id=128408429&pr_number=39&repository=vendurehq%2Fcommunity-plugins&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fcommunity-plugins%2Fpull%2F39&signature=c3a3ed3581416d9544285a30fb7310f6e6cc0f3e6aedd2e05aea2e7b1d19237f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->